### PR TITLE
feat(server): define RequestBundle and ResponseBundle Pydantic models

### DIFF
--- a/server/conftest.py
+++ b/server/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure server/ is on sys.path so test files can import local modules directly.
+sys.path.insert(0, str(Path(__file__).parent))

--- a/server/models.py
+++ b/server/models.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RequestBundle(BaseModel):
+    """Bundle sent by an Android node to request content from the server."""
+
+    model_config = ConfigDict(frozen=True)
+
+    node_id: str
+    query_id: str
+    query_string: str  # plain text → search; starts with "/" → article fetch
+    timestamp: int = Field(gt=0)  # Unix seconds
+    ttl_seconds: int = Field(gt=0)
+    hop_count: int = Field(ge=0)
+    signature: Optional[str] = None  # base64 Ed25519; None until issue #9 signs it
+
+
+class ResponseBundle(BaseModel):
+    """One chunk of a server response to a RequestBundle."""
+
+    model_config = ConfigDict(frozen=True)
+
+    server_id: str
+    query_id: str  # matches the originating RequestBundle.query_id
+    chunk_index: int = Field(ge=0)
+    total_chunks: int = Field(ge=1)
+    content_type: str
+    payload_b64: str  # base64-encoded bytes for this chunk
+    sha256: str  # hex SHA-256 of the decoded chunk payload for per-chunk integrity
+    signature: Optional[str] = None  # base64 Ed25519; None until issue #9 signs it

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8,<9
+pytest-asyncio>=0.23,<1.0

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -1,0 +1,94 @@
+import time
+
+import pytest
+from pydantic import ValidationError
+
+from models import RequestBundle, ResponseBundle
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_request_data() -> dict:
+    return {
+        "node_id": "550e8400-e29b-41d4-a716-446655440000",
+        "query_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        "query_string": "water cycle",
+        "timestamp": int(time.time()),
+        "ttl_seconds": 3600,
+        "hop_count": 0,
+    }
+
+
+@pytest.fixture
+def valid_response_data() -> dict:
+    return {
+        "server_id": "wake-server-01",
+        "query_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        "chunk_index": 0,
+        "total_chunks": 3,
+        "content_type": "text/html; charset=utf-8",
+        "payload_b64": "PGh0bWw+SGVsbG88L2h0bWw+",
+        "sha256": "a" * 64,
+    }
+
+
+# ---------------------------------------------------------------------------
+# RequestBundle tests
+# ---------------------------------------------------------------------------
+
+
+def test_request_bundle_valid(valid_request_data: dict) -> None:
+    bundle = RequestBundle(**valid_request_data)
+    dumped = bundle.model_dump()
+    assert dumped["node_id"] == valid_request_data["node_id"]
+    assert dumped["query_string"] == "water cycle"
+    assert dumped["hop_count"] == 0
+    assert dumped["signature"] is None
+
+
+def test_request_bundle_signature_defaults_none(valid_request_data: dict) -> None:
+    bundle = RequestBundle(**valid_request_data)
+    assert bundle.signature is None
+
+
+def test_request_bundle_invalid_hop_count(valid_request_data: dict) -> None:
+    with pytest.raises(ValidationError):
+        RequestBundle(**{**valid_request_data, "hop_count": -1})
+
+
+def test_request_bundle_invalid_ttl(valid_request_data: dict) -> None:
+    with pytest.raises(ValidationError):
+        RequestBundle(**{**valid_request_data, "ttl_seconds": 0})
+
+
+# ---------------------------------------------------------------------------
+# ResponseBundle tests
+# ---------------------------------------------------------------------------
+
+
+def test_response_bundle_valid(valid_response_data: dict) -> None:
+    bundle = ResponseBundle(**valid_response_data)
+    dumped = bundle.model_dump()
+    assert dumped["server_id"] == "wake-server-01"
+    assert dumped["chunk_index"] == 0
+    assert dumped["total_chunks"] == 3
+    assert dumped["signature"] is None
+
+
+def test_response_bundle_signature_defaults_none(valid_response_data: dict) -> None:
+    bundle = ResponseBundle(**valid_response_data)
+    assert bundle.signature is None
+
+
+def test_response_bundle_invalid_chunk_index(valid_response_data: dict) -> None:
+    with pytest.raises(ValidationError):
+        ResponseBundle(**{**valid_response_data, "chunk_index": -1})
+
+
+def test_response_bundle_invalid_total_chunks(valid_response_data: dict) -> None:
+    with pytest.raises(ValidationError):
+        ResponseBundle(**{**valid_response_data, "total_chunks": 0})


### PR DESCRIPTION
Adds server/models.py with frozen Pydantic v2 models for both bundle types. signature is Optional to allow pre-signing state during development (populated in issue #9). sha256 is per-chunk so Android can verify integrity as each chunk arrives.

Also adds requirements-dev.txt, conftest.py for sys.path setup, and test_models.py with 8 passing tests covering happy-path round-trips and Field constraint validation.

Closes #12 