### PR TITLE
feat(database): introduce BundleStoreManager and update database schema

### DIFF
--- a/android/app/schemas/com.wake.dtn.data.WakeDatabase/3.json
+++ b/android/app/schemas/com.wake.dtn.data.WakeDatabase/3.json
@@ -1,0 +1,52 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "REGENERATED_BY_KSP_ON_FIRST_BUILD",
+    "entities": [
+      {
+        "tableName": "bundles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bundleId` TEXT NOT NULL, `bundleType` TEXT NOT NULL, `queryId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `timestampMs` INTEGER NOT NULL, `ttlSeconds` INTEGER NOT NULL, `hopCount` INTEGER NOT NULL, `signature` TEXT, `queryString` TEXT, `chunkIndex` INTEGER NOT NULL, `totalChunks` INTEGER NOT NULL, `contentType` TEXT, `payloadSha256` TEXT, `payloadFilePath` TEXT, `receivedAtMs` INTEGER NOT NULL, `isDelivered` INTEGER NOT NULL, `payloadSizeBytes` INTEGER NOT NULL, PRIMARY KEY(`bundleId`))",
+        "fields": [
+          { "fieldPath": "bundleId", "columnName": "bundleId", "affinity": "TEXT", "notNull": true },
+          { "fieldPath": "bundleType", "columnName": "bundleType", "affinity": "TEXT", "notNull": true },
+          { "fieldPath": "queryId", "columnName": "queryId", "affinity": "TEXT", "notNull": true },
+          { "fieldPath": "sourceId", "columnName": "sourceId", "affinity": "TEXT", "notNull": true },
+          { "fieldPath": "timestampMs", "columnName": "timestampMs", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "ttlSeconds", "columnName": "ttlSeconds", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "hopCount", "columnName": "hopCount", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "signature", "columnName": "signature", "affinity": "TEXT", "notNull": false },
+          { "fieldPath": "queryString", "columnName": "queryString", "affinity": "TEXT", "notNull": false },
+          { "fieldPath": "chunkIndex", "columnName": "chunkIndex", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "totalChunks", "columnName": "totalChunks", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "contentType", "columnName": "contentType", "affinity": "TEXT", "notNull": false },
+          { "fieldPath": "payloadSha256", "columnName": "payloadSha256", "affinity": "TEXT", "notNull": false },
+          { "fieldPath": "payloadFilePath", "columnName": "payloadFilePath", "affinity": "TEXT", "notNull": false },
+          { "fieldPath": "receivedAtMs", "columnName": "receivedAtMs", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "isDelivered", "columnName": "isDelivered", "affinity": "INTEGER", "notNull": true },
+          { "fieldPath": "payloadSizeBytes", "columnName": "payloadSizeBytes", "affinity": "INTEGER", "notNull": true }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [ "bundleId" ]
+        }
+      },
+      {
+        "tableName": "seen_ids",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bundle_id` TEXT NOT NULL, `seen_at` INTEGER NOT NULL, PRIMARY KEY(`bundle_id`))",
+        "fields": [
+          { "fieldPath": "bundleId", "columnName": "bundle_id", "affinity": "TEXT", "notNull": true },
+          { "fieldPath": "seenAtMs", "columnName": "seen_at", "affinity": "INTEGER", "notNull": true }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [ "bundle_id" ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'REGENERATED_BY_KSP_ON_FIRST_BUILD')"
+    ]
+  }
+}

--- a/android/app/schemas/com.wake.dtn.data.WakeDatabase/3.json
+++ b/android/app/schemas/com.wake.dtn.data.WakeDatabase/3.json
@@ -2,51 +2,145 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "REGENERATED_BY_KSP_ON_FIRST_BUILD",
+    "identityHash": "968bfdb9bd8c3f191b82af133351b0c0",
     "entities": [
       {
         "tableName": "bundles",
         "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bundleId` TEXT NOT NULL, `bundleType` TEXT NOT NULL, `queryId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `timestampMs` INTEGER NOT NULL, `ttlSeconds` INTEGER NOT NULL, `hopCount` INTEGER NOT NULL, `signature` TEXT, `queryString` TEXT, `chunkIndex` INTEGER NOT NULL, `totalChunks` INTEGER NOT NULL, `contentType` TEXT, `payloadSha256` TEXT, `payloadFilePath` TEXT, `receivedAtMs` INTEGER NOT NULL, `isDelivered` INTEGER NOT NULL, `payloadSizeBytes` INTEGER NOT NULL, PRIMARY KEY(`bundleId`))",
         "fields": [
-          { "fieldPath": "bundleId", "columnName": "bundleId", "affinity": "TEXT", "notNull": true },
-          { "fieldPath": "bundleType", "columnName": "bundleType", "affinity": "TEXT", "notNull": true },
-          { "fieldPath": "queryId", "columnName": "queryId", "affinity": "TEXT", "notNull": true },
-          { "fieldPath": "sourceId", "columnName": "sourceId", "affinity": "TEXT", "notNull": true },
-          { "fieldPath": "timestampMs", "columnName": "timestampMs", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "ttlSeconds", "columnName": "ttlSeconds", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "hopCount", "columnName": "hopCount", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "signature", "columnName": "signature", "affinity": "TEXT", "notNull": false },
-          { "fieldPath": "queryString", "columnName": "queryString", "affinity": "TEXT", "notNull": false },
-          { "fieldPath": "chunkIndex", "columnName": "chunkIndex", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "totalChunks", "columnName": "totalChunks", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "contentType", "columnName": "contentType", "affinity": "TEXT", "notNull": false },
-          { "fieldPath": "payloadSha256", "columnName": "payloadSha256", "affinity": "TEXT", "notNull": false },
-          { "fieldPath": "payloadFilePath", "columnName": "payloadFilePath", "affinity": "TEXT", "notNull": false },
-          { "fieldPath": "receivedAtMs", "columnName": "receivedAtMs", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "isDelivered", "columnName": "isDelivered", "affinity": "INTEGER", "notNull": true },
-          { "fieldPath": "payloadSizeBytes", "columnName": "payloadSizeBytes", "affinity": "INTEGER", "notNull": true }
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundleId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleType",
+            "columnName": "bundleType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queryId",
+            "columnName": "queryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ttlSeconds",
+            "columnName": "ttlSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hopCount",
+            "columnName": "hopCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signature",
+            "columnName": "signature",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "queryString",
+            "columnName": "queryString",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chunkIndex",
+            "columnName": "chunkIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalChunks",
+            "columnName": "totalChunks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSha256",
+            "columnName": "payloadSha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadFilePath",
+            "columnName": "payloadFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "receivedAtMs",
+            "columnName": "receivedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDelivered",
+            "columnName": "isDelivered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadSizeBytes",
+            "columnName": "payloadSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
         ],
         "primaryKey": {
           "autoGenerate": false,
-          "columnNames": [ "bundleId" ]
+          "columnNames": [
+            "bundleId"
+          ]
         }
       },
       {
         "tableName": "seen_ids",
         "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bundle_id` TEXT NOT NULL, `seen_at` INTEGER NOT NULL, PRIMARY KEY(`bundle_id`))",
         "fields": [
-          { "fieldPath": "bundleId", "columnName": "bundle_id", "affinity": "TEXT", "notNull": true },
-          { "fieldPath": "seenAtMs", "columnName": "seen_at", "affinity": "INTEGER", "notNull": true }
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAtMs",
+            "columnName": "seen_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
         ],
         "primaryKey": {
           "autoGenerate": false,
-          "columnNames": [ "bundle_id" ]
+          "columnNames": [
+            "bundle_id"
+          ]
         }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'REGENERATED_BY_KSP_ON_FIRST_BUILD')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '968bfdb9bd8c3f191b82af133351b0c0')"
     ]
   }
 }

--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleDaoTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleDaoTest.kt
@@ -154,4 +154,17 @@ class BundleDaoTest {
         val ordered = dao.getAllByReceivedTime()
         assertEquals(listOf(100L, 200L, 300L), ordered.map { it.receivedAtMs })
     }
+
+    @Test
+    fun getTotalPayloadBytes_returnsZeroOnEmptyTable() = runTest {
+        assertEquals(0L, dao.getTotalPayloadBytes())
+    }
+
+    @Test
+    fun getTotalPayloadBytes_sumMatchesInsertedRows() = runTest {
+        dao.insert(responseChunk(chunkIndex = 0).copy(payloadSizeBytes = 100L))
+        dao.insert(responseChunk(chunkIndex = 1).copy(payloadSizeBytes = 250L))
+        dao.insert(requestBundle()) // REQUEST bundles have payloadSizeBytes = 0 by default
+        assertEquals(350L, dao.getTotalPayloadBytes())
+    }
 }

--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleDaoTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleDaoTest.kt
@@ -147,12 +147,15 @@ class BundleDaoTest {
     }
 
     @Test
-    fun getAllByReceivedTimeIsAscending() = runTest {
-        dao.insert(responseChunk(chunkIndex = 0, receivedAtMs = 300L))
-        dao.insert(responseChunk(chunkIndex = 1, receivedAtMs = 100L))
-        dao.insert(requestBundle(queryId = "other", bundleId = "other", receivedAtMs = 200L))
+    fun getAllByReceivedTime_isAscendingAndExcludesZeroByteRows() = runTest {
+        dao.insert(responseChunk(chunkIndex = 0, receivedAtMs = 300L).copy(payloadSizeBytes = 50L))
+        dao.insert(responseChunk(chunkIndex = 1, receivedAtMs = 100L).copy(payloadSizeBytes = 30L))
+        // Zero-byte rows: one REQUEST bundle and one RESPONSE with no stored payload.
+        dao.insert(requestBundle(queryId = "req", bundleId = "req", receivedAtMs = 200L))
+        dao.insert(responseChunk(queryId = "empty", chunkIndex = 0, receivedAtMs = 50L))
         val ordered = dao.getAllByReceivedTime()
-        assertEquals(listOf(100L, 200L, 300L), ordered.map { it.receivedAtMs })
+        // Only the two rows with payloadSizeBytes > 0 should be returned, oldest first.
+        assertEquals(listOf(100L, 300L), ordered.map { it.receivedAtMs })
     }
 
     @Test

--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
@@ -1,0 +1,246 @@
+package com.wake.dtn.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class BundleStoreManagerTest {
+
+    private lateinit var db: WakeDatabase
+    private lateinit var manager: BundleStoreManager
+    private lateinit var testFilesDir: File
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(context, WakeDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        // Isolate test files from real app data.
+        testFilesDir = File(context.filesDir, "test_bundle_store").also { it.mkdirs() }
+
+        // 100-byte cap makes LRU eviction easy to trigger in tests.
+        manager = BundleStoreManager(
+            context = object : android.content.ContextWrapper(context) {
+                override fun getFilesDir(): File = testFilesDir
+            },
+            dao = db.bundleDao(),
+            maxStoreBytes = 100L,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        testFilesDir.deleteRecursively()
+    }
+
+    // --- helpers ---
+
+    private fun responseEntity(
+        queryId: String = "q1",
+        chunkIndex: Int = 0,
+        receivedAtMs: Long = 1_000L,
+        ttlSeconds: Int = 3_600,
+        payloadSizeBytes: Long = 0,
+    ) = BundleEntity(
+        bundleId = "$queryId:$chunkIndex",
+        bundleType = BundleType.RESPONSE,
+        queryId = queryId,
+        sourceId = "server",
+        timestampMs = 500L,
+        ttlSeconds = ttlSeconds,
+        hopCount = 1,
+        signature = null,
+        queryString = null,
+        chunkIndex = chunkIndex,
+        totalChunks = 1,
+        contentType = "text/html",
+        payloadSha256 = null,
+        payloadFilePath = "${queryId}_${chunkIndex}.bundle",
+        receivedAtMs = receivedAtMs,
+        payloadSizeBytes = payloadSizeBytes,
+    )
+
+    private fun requestEntity(
+        queryId: String = "q1",
+        receivedAtMs: Long = 1_000L,
+        ttlSeconds: Int = 3_600,
+    ) = BundleEntity(
+        bundleId = queryId,
+        bundleType = BundleType.REQUEST,
+        queryId = queryId,
+        sourceId = "node-a",
+        timestampMs = 400L,
+        ttlSeconds = ttlSeconds,
+        hopCount = 0,
+        signature = null,
+        queryString = "water cycle",
+        chunkIndex = 0,
+        totalChunks = 1,
+        contentType = null,
+        payloadSha256 = null,
+        payloadFilePath = null,
+        receivedAtMs = receivedAtMs,
+    )
+
+    // --- store ---
+
+    @Test
+    fun store_insertsEntityIntoDb() = runTest {
+        manager.store(responseEntity())
+        assertNotNull(db.bundleDao().getById("q1:0"))
+    }
+
+    @Test
+    fun store_writesPayloadFileToFilesDir() = runTest {
+        val payload = "hello world".toByteArray()
+        manager.store(responseEntity(), payload)
+
+        val file = File(testFilesDir, "q1_0.bundle")
+        assertTrue(file.exists())
+        assertArrayEquals(payload, file.readBytes())
+    }
+
+    @Test
+    fun store_recordsPayloadSizeBytesInDb() = runTest {
+        val payload = ByteArray(60) { it.toByte() }
+        manager.store(responseEntity(), payload)
+
+        val stored = db.bundleDao().getById("q1:0")!!
+        assertEquals(60L, stored.payloadSizeBytes)
+    }
+
+    @Test
+    fun store_duplicateIgnored_fileNotOverwritten() = runTest {
+        val original = "original".toByteArray()
+        manager.store(responseEntity(), original)
+        manager.store(responseEntity(), "overwrite".toByteArray())
+
+        assertArrayEquals(original, File(testFilesDir, "q1_0.bundle").readBytes())
+        // DB row stays at original size
+        assertEquals(original.size.toLong(), db.bundleDao().getById("q1:0")!!.payloadSizeBytes)
+    }
+
+    @Test
+    fun store_noPayload_noFileCreated() = runTest {
+        manager.store(responseEntity())
+        assertFalse(File(testFilesDir, "q1_0.bundle").exists())
+    }
+
+    @Test
+    fun store_requestBundle_noFileWritten() = runTest {
+        manager.store(requestEntity())
+        assertNotNull(db.bundleDao().getById("q1"))
+        // filesDir should be empty — no payloadFilePath on REQUEST
+        assertEquals(0, testFilesDir.listFiles()?.size ?: 0)
+    }
+
+    // --- getById / getResponseChunks ---
+
+    @Test
+    fun getById_returnsNullIfAbsent() = runTest {
+        assertNull(manager.getById("nonexistent"))
+    }
+
+    @Test
+    fun getResponseChunks_returnsChunksInOrder() = runTest {
+        manager.store(responseEntity(chunkIndex = 1))
+        manager.store(responseEntity(chunkIndex = 0))
+        val chunks = manager.getResponseChunks("q1")
+        assertEquals(2, chunks.size)
+        assertEquals(0, chunks[0].chunkIndex)
+        assertEquals(1, chunks[1].chunkIndex)
+    }
+
+    // --- markDelivered ---
+
+    @Test
+    fun markDelivered_setsIsDeliveredTrue() = runTest {
+        manager.store(responseEntity())
+        manager.markDelivered("q1:0")
+        assertTrue(db.bundleDao().getById("q1:0")!!.isDelivered)
+    }
+
+    @Test
+    fun markDelivered_noopForUnknownId() = runTest {
+        // Must not throw
+        manager.markDelivered("unknown-bundle")
+    }
+
+    // --- TTL eviction ---
+
+    @Test
+    fun runTtlEviction_removesExpiredBundleAndFile() = runTest {
+        val payload = ByteArray(10)
+        // receivedAtMs=1000, ttlSeconds=1 → expires at 2000 ms
+        manager.store(responseEntity(receivedAtMs = 1_000L, ttlSeconds = 1), payload)
+
+        manager.runTtlEviction(nowMs = 3_000L)
+
+        assertNull(db.bundleDao().getById("q1:0"))
+        assertFalse(File(testFilesDir, "q1_0.bundle").exists())
+    }
+
+    @Test
+    fun runTtlEviction_keepsUnexpiredBundle() = runTest {
+        // receivedAtMs=1000, ttlSeconds=3600 → expires at 3_601_000 ms
+        manager.store(responseEntity(receivedAtMs = 1_000L, ttlSeconds = 3_600))
+
+        manager.runTtlEviction(nowMs = 3_000L)
+
+        assertNotNull(db.bundleDao().getById("q1:0"))
+    }
+
+    // --- LRU eviction ---
+
+    @Test
+    fun runLruEviction_noopWhenUnderCap() = runTest {
+        // maxStoreBytes=100; 40 bytes is under cap
+        manager.store(responseEntity(receivedAtMs = 1_000L), ByteArray(40))
+        manager.runLruEviction()
+        assertNotNull(db.bundleDao().getById("q1:0"))
+    }
+
+    @Test
+    fun runLruEviction_evictsOldestWhenOverCap() = runTest {
+        // maxStoreBytes=100. Store 60 bytes old + 60 bytes new = 120 bytes → over cap.
+        // LRU should evict the oldest (q1:0, receivedAtMs=100) to bring total to 60.
+        manager.store(responseEntity(queryId = "q1", chunkIndex = 0, receivedAtMs = 100L), ByteArray(60))
+        manager.store(responseEntity(queryId = "q2", chunkIndex = 0, receivedAtMs = 200L), ByteArray(60))
+
+        // Second store triggers runLruEviction internally
+        assertNull(db.bundleDao().getById("q1:0"))
+        assertFalse(File(testFilesDir, "q1_0.bundle").exists())
+        assertNotNull(db.bundleDao().getById("q2:0"))
+    }
+
+    @Test
+    fun runLruEviction_evictsMultipleBundlesIfNeeded() = runTest {
+        // Three 40-byte bundles = 120 bytes. Cap = 100. Must evict the two oldest.
+        manager.store(responseEntity(queryId = "q1", chunkIndex = 0, receivedAtMs = 100L), ByteArray(40))
+        manager.store(responseEntity(queryId = "q2", chunkIndex = 0, receivedAtMs = 200L), ByteArray(40))
+        manager.store(responseEntity(queryId = "q3", chunkIndex = 0, receivedAtMs = 300L), ByteArray(40))
+
+        // After third store: 120 bytes stored, need to free 20+ bytes.
+        // Oldest is q1 (40 bytes) — evicting it brings us to 80, which is under cap.
+        assertNull(db.bundleDao().getById("q1:0"))
+        assertNotNull(db.bundleDao().getById("q2:0"))
+        assertNotNull(db.bundleDao().getById("q3:0"))
+    }
+}

--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class BundleStoreManagerTest {
@@ -144,6 +145,14 @@ class BundleStoreManagerTest {
     }
 
     @Test
+    fun store_noTempFilesRemainAfterSuccessfulStore() = runTest {
+        manager.store(responseEntity(), ByteArray(10))
+        val files = testFilesDir.listFiles() ?: emptyArray()
+        assertTrue("expected exactly one file", files.size == 1)
+        assertFalse("temp file must not survive", files[0].name.endsWith(".tmp"))
+    }
+
+    @Test
     fun store_requestBundle_noFileWritten() = runTest {
         manager.store(requestEntity())
         assertNotNull(db.bundleDao().getById("q1"))
@@ -242,5 +251,34 @@ class BundleStoreManagerTest {
         assertNull(db.bundleDao().getById("q1:0"))
         assertNotNull(db.bundleDao().getById("q2:0"))
         assertNotNull(db.bundleDao().getById("q3:0"))
+    }
+
+    @Test
+    fun runLruEviction_doesNotEvictZeroByteRows() = runTest {
+        // Store a REQUEST bundle (no payload, payloadSizeBytes = 0) at the oldest timestamp.
+        // Then push the store over the cap with a real payload bundle.
+        // LRU must free space by evicting the payload bundle, not the zero-byte REQUEST row.
+        manager.store(requestEntity(queryId = "req", receivedAtMs = 50L))
+        manager.store(responseEntity(queryId = "q1", chunkIndex = 0, receivedAtMs = 200L), ByteArray(60))
+        manager.store(responseEntity(queryId = "q2", chunkIndex = 0, receivedAtMs = 300L), ByteArray(60))
+
+        // Cap = 100; 120 bytes stored. LRU should evict q1 (oldest payload), not the REQUEST row.
+        assertNotNull(db.bundleDao().getById("req"))
+        assertNull(db.bundleDao().getById("q1:0"))
+        assertNotNull(db.bundleDao().getById("q2:0"))
+    }
+
+    // --- path traversal guard ---
+
+    @Test(expected = IOException::class)
+    fun store_rejectsPathTraversal() = runTest {
+        val traversalEntity = responseEntity().copy(payloadFilePath = "../escape.txt")
+        manager.store(traversalEntity, "should not write".toByteArray())
+    }
+
+    @Test(expected = IOException::class)
+    fun store_rejectsAbsolutePath() = runTest {
+        val absoluteEntity = responseEntity().copy(payloadFilePath = "/data/data/com.wake.dtn/evil.txt")
+        manager.store(absoluteEntity, "should not write".toByteArray())
     }
 }

--- a/android/app/src/main/java/com/wake/dtn/data/BundleDao.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/BundleDao.kt
@@ -23,13 +23,17 @@ interface BundleDao {
     @Query("SELECT * FROM bundles WHERE bundleType = 'RESPONSE' AND queryId = :queryId ORDER BY chunkIndex ASC")
     suspend fun getResponseChunks(queryId: String): List<BundleEntity>
 
-    /** All bundles ordered oldest-received-first — primary input for LRU eviction in #14. */
+    /** All bundles ordered oldest-received-first — primary input for LRU eviction. */
     @Query("SELECT * FROM bundles ORDER BY receivedAtMs ASC")
     suspend fun getAllByReceivedTime(): List<BundleEntity>
 
-    /** Bundles whose TTL window has elapsed — primary input for TTL eviction in #14. */
+    /** Bundles whose TTL window has elapsed — primary input for TTL eviction. */
     @Query("SELECT * FROM bundles WHERE (receivedAtMs + ttlSeconds * 1000) < :nowMs")
     suspend fun getExpired(nowMs: Long): List<BundleEntity>
+
+    /** Total bytes of stored payload files — used by LRU cap check. COALESCE handles empty table. */
+    @Query("SELECT COALESCE(SUM(payloadSizeBytes), 0) FROM bundles")
+    suspend fun getTotalPayloadBytes(): Long
 
     @Delete
     suspend fun delete(bundle: BundleEntity)

--- a/android/app/src/main/java/com/wake/dtn/data/BundleDao.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/BundleDao.kt
@@ -23,8 +23,12 @@ interface BundleDao {
     @Query("SELECT * FROM bundles WHERE bundleType = 'RESPONSE' AND queryId = :queryId ORDER BY chunkIndex ASC")
     suspend fun getResponseChunks(queryId: String): List<BundleEntity>
 
-    /** All bundles ordered oldest-received-first — primary input for LRU eviction. */
-    @Query("SELECT * FROM bundles ORDER BY receivedAtMs ASC")
+    /**
+     * Bundles that actually occupy disk space, ordered oldest-received-first.
+     * Zero-byte rows (REQUEST bundles, or RESPONSE rows with no stored payload) are excluded
+     * so LRU eviction only touches candidates that can actually free storage.
+     */
+    @Query("SELECT * FROM bundles WHERE payloadSizeBytes > 0 ORDER BY receivedAtMs ASC")
     suspend fun getAllByReceivedTime(): List<BundleEntity>
 
     /** Bundles whose TTL window has elapsed — primary input for TTL eviction. */

--- a/android/app/src/main/java/com/wake/dtn/data/BundleEntity.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/BundleEntity.kt
@@ -43,4 +43,6 @@ data class BundleEntity(
     /** Wall-clock time this node received/stored the bundle (epoch ms). Used for LRU eviction. */
     val receivedAtMs: Long,
     val isDelivered: Boolean = false,
+    /** Size of the stored payload file in bytes. Zero for REQUEST bundles and missing files. */
+    val payloadSizeBytes: Long = 0,
 )

--- a/android/app/src/main/java/com/wake/dtn/data/BundleStoreManager.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/BundleStoreManager.kt
@@ -1,0 +1,98 @@
+package com.wake.dtn.data
+
+import android.content.Context
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+
+/**
+ * Single entry point for all bundle I/O: write metadata to Room, write payload bytes to
+ * filesDir, and enforce eviction policies so the node never exceeds [maxStoreBytes].
+ *
+ * Two eviction passes run independently:
+ *  - TTL: remove any bundle whose TTL window has elapsed (called periodically by WakeService).
+ *  - LRU: after every [store], if total payload bytes exceed [maxStoreBytes], discard the
+ *    oldest-received bundles until we are back under the cap.
+ *
+ * [maxStoreBytes] is a constructor parameter (default 500 MB) so tests can exercise the LRU
+ * path with small payloads without writing gigabytes of test data.
+ */
+class BundleStoreManager(
+    private val context: Context,
+    private val dao: BundleDao,
+    val maxStoreBytes: Long = MAX_STORE_BYTES,
+) {
+
+    private val filesDir: File get() = context.filesDir
+
+    /**
+     * Serializes the check-write-insert sequence so that two concurrent calls with the same
+     * bundleId cannot both pass the existence check and produce a file whose bytes disagree
+     * with the size recorded in the database.
+     */
+    private val storeMutex = Mutex()
+
+    /**
+     * Persist a bundle. If [payload] is provided and the entity has a [BundleEntity.payloadFilePath],
+     * the bytes are written to [filesDir] and the size is recorded in [BundleEntity.payloadSizeBytes].
+     *
+     * Duplicate bundleIds are silently ignored. The [storeMutex] makes the existence-check,
+     * file-write, and DB-insert atomic with respect to other concurrent [store] callers, so
+     * the file on disk and the size in the database are always consistent.
+     */
+    suspend fun store(entity: BundleEntity, payload: ByteArray? = null) {
+        storeMutex.withLock {
+            if (dao.getById(entity.bundleId) != null) return
+
+            val entityToInsert = if (payload != null && entity.payloadFilePath != null) {
+                File(filesDir, entity.payloadFilePath).writeBytes(payload)
+                entity.copy(payloadSizeBytes = payload.size.toLong())
+            } else {
+                entity
+            }
+
+            dao.insert(entityToInsert)
+        }
+        runLruEviction()
+    }
+
+    suspend fun getById(bundleId: String): BundleEntity? = dao.getById(bundleId)
+
+    suspend fun getResponseChunks(queryId: String): List<BundleEntity> =
+        dao.getResponseChunks(queryId)
+
+    suspend fun markDelivered(bundleId: String) {
+        dao.getById(bundleId)?.let { dao.update(it.copy(isDelivered = true)) }
+    }
+
+    /** Delete every bundle whose TTL window has elapsed. */
+    suspend fun runTtlEviction(nowMs: Long = System.currentTimeMillis()) {
+        dao.getExpired(nowMs).forEach { evict(it) }
+    }
+
+    /**
+     * Delete oldest bundles (by [BundleEntity.receivedAtMs]) until total payload bytes are
+     * back under [maxStoreBytes]. No-op if already under cap.
+     */
+    suspend fun runLruEviction() {
+        val totalBytes = dao.getTotalPayloadBytes()
+        if (totalBytes <= maxStoreBytes) return
+
+        var bytesToFree = totalBytes - maxStoreBytes
+        for (bundle in dao.getAllByReceivedTime()) {
+            if (bytesToFree <= 0) break
+            bytesToFree -= bundle.payloadSizeBytes
+            evict(bundle)
+        }
+    }
+
+    /** Remove a bundle's payload file (if any) and its DB row. */
+    private suspend fun evict(entity: BundleEntity) {
+        entity.payloadFilePath?.let { File(filesDir, it).delete() }
+        dao.delete(entity)
+    }
+
+    companion object {
+        const val MAX_STORE_BYTES = 500L * 1024 * 1024
+    }
+}

--- a/android/app/src/main/java/com/wake/dtn/data/BundleStoreManager.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/BundleStoreManager.kt
@@ -1,9 +1,11 @@
 package com.wake.dtn.data
 
 import android.content.Context
+import android.util.Log
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
+import java.io.IOException
 
 /**
  * Single entry point for all bundle I/O: write metadata to Room, write payload bytes to
@@ -44,14 +46,28 @@ class BundleStoreManager(
         storeMutex.withLock {
             if (dao.getById(entity.bundleId) != null) return
 
-            val entityToInsert = if (payload != null && entity.payloadFilePath != null) {
-                File(filesDir, entity.payloadFilePath).writeBytes(payload)
-                entity.copy(payloadSizeBytes = payload.size.toLong())
+            if (payload != null && entity.payloadFilePath != null) {
+                val finalFile = safeFile(entity.payloadFilePath)
+                    ?: throw IOException("Rejected payload path outside filesDir: ${entity.payloadFilePath}")
+                // Write to a sibling .tmp file so a failed DB insert never leaves a
+                // stray payload file at the real path. The rename below is atomic
+                // (same directory, same filesystem) and only executes after the DB row
+                // is committed, keeping disk and DB in sync.
+                val tempFile = File(finalFile.parent, "${finalFile.name}.tmp")
+                tempFile.writeBytes(payload)
+                try {
+                    dao.insert(entity.copy(payloadSizeBytes = payload.size.toLong()))
+                } catch (e: Exception) {
+                    tempFile.delete()
+                    throw e
+                }
+                if (!tempFile.renameTo(finalFile)) {
+                    tempFile.delete()
+                    throw IOException("Failed to commit payload file: ${entity.payloadFilePath}")
+                }
             } else {
-                entity
+                dao.insert(entity)
             }
-
-            dao.insert(entityToInsert)
         }
         runLruEviction()
     }
@@ -88,11 +104,36 @@ class BundleStoreManager(
 
     /** Remove a bundle's payload file (if any) and its DB row. */
     private suspend fun evict(entity: BundleEntity) {
-        entity.payloadFilePath?.let { File(filesDir, it).delete() }
+        entity.payloadFilePath?.let { path ->
+            val file = safeFile(path)
+            if (file != null && file.exists() && !file.delete()) {
+                // File exists but could not be deleted (e.g. transient I/O error). The DB row is
+                // still removed below so eviction makes forward progress; the orphaned file will
+                // be cleaned up if a future eviction pass can delete it.
+                Log.w(TAG, "Failed to delete payload file: $path (bundleId=${entity.bundleId})")
+            }
+        }
         dao.delete(entity)
     }
 
+    /**
+     * Resolves [relativePath] against [filesDir] and returns the [File] only if the canonical
+     * path is still inside [filesDir]. Returns null for any path that would escape the directory
+     * (absolute paths, `../` traversal, symlinks that point outside, etc.).
+     */
+    private fun safeFile(relativePath: String): File? {
+        val resolved = File(filesDir, relativePath).canonicalFile
+        return if (resolved.path.startsWith(filesDir.canonicalPath + File.separator) ||
+            resolved == filesDir.canonicalFile
+        ) {
+            resolved
+        } else {
+            null
+        }
+    }
+
     companion object {
+        private const val TAG = "BundleStoreManager"
         const val MAX_STORE_BYTES = 500L * 1024 * 1024
     }
 }

--- a/android/app/src/main/java/com/wake/dtn/data/WakeDatabase.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/WakeDatabase.kt
@@ -10,7 +10,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [BundleEntity::class, SeenIdEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -21,6 +21,14 @@ abstract class WakeDatabase : RoomDatabase() {
 
     companion object {
         @Volatile private var instance: WakeDatabase? = null
+
+        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE bundles ADD COLUMN payloadSizeBytes INTEGER NOT NULL DEFAULT 0",
+                )
+            }
+        }
 
         /** v1 used camelCase columns; align with server `bundle_id` / `seen_at`. */
         val MIGRATION_1_2: Migration = object : Migration(1, 2) {
@@ -51,7 +59,7 @@ abstract class WakeDatabase : RoomDatabase() {
                     context.applicationContext,
                     WakeDatabase::class.java,
                     "wake.db",
-                ).addMigrations(MIGRATION_1_2)
+                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build().also { instance = it }
             }
     }

--- a/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
@@ -8,6 +8,7 @@ import android.os.IBinder
 import androidx.core.content.ContextCompat
 import com.wake.dtn.data.BundleStoreManager
 import com.wake.dtn.data.WakeDatabase
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -42,7 +43,11 @@ class WakeService : Service() {
         scope.launch {
             while (isActive) {
                 delay(TTL_CHECK_INTERVAL_MS)
-                bundleStoreManager.runTtlEviction()
+                try {
+                    bundleStoreManager.runTtlEviction()
+                } catch (e: Exception) {
+                    Log.e(TAG, "TTL eviction failed; will retry next interval", e)
+                }
             }
         }
     }
@@ -60,6 +65,7 @@ class WakeService : Service() {
     }
 
     companion object {
+        private const val TAG = "WakeService"
         const val NOTIFICATION_ID = 1
         const val TTL_CHECK_INTERVAL_MS = 5 * 60 * 1_000L
 

--- a/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
@@ -6,15 +6,22 @@ import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
 import androidx.core.content.ContextCompat
+import com.wake.dtn.data.BundleStoreManager
+import com.wake.dtn.data.WakeDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 class WakeService : Service() {
 
-    // Coroutine scope tied to the service lifetime. Issues #14/#15 will launch work here.
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    lateinit var bundleStoreManager: BundleStoreManager
+        private set
 
     private val binder = LocalBinder()
 
@@ -26,6 +33,18 @@ class WakeService : Service() {
         super.onCreate()
         NotificationHelper.createChannel(this)
         startForeground(NOTIFICATION_ID, NotificationHelper.buildNotification(this))
+
+        bundleStoreManager = BundleStoreManager(
+            context = this,
+            dao = WakeDatabase.getInstance(this).bundleDao(),
+        )
+
+        scope.launch {
+            while (isActive) {
+                delay(TTL_CHECK_INTERVAL_MS)
+                bundleStoreManager.runTtlEviction()
+            }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -42,6 +61,7 @@ class WakeService : Service() {
 
     companion object {
         const val NOTIFICATION_ID = 1
+        const val TTL_CHECK_INTERVAL_MS = 5 * 60 * 1_000L
 
         fun start(context: Context) {
             ContextCompat.startForegroundService(


### PR DESCRIPTION
- Added a new `BundleStoreManager` class to handle bundle storage, including payload management and eviction policies (TTL and LRU).
- Introduced a new database schema version (3) with an additional `payloadSizeBytes` column in the `bundles` table to track the size of stored payload files.
- Implemented migration from version 2 to 3 to accommodate the new column.
- Created comprehensive unit tests for `BundleStoreManager` to ensure correct functionality of storage and eviction logic.
- Updated `WakeService` to utilize `BundleStoreManager` for managing bundle operations in the background.
Closes #31 