### PR TITLE
feat(android): add Kotlin and Android conventions for WAKE app

### DIFF
--- a/.claude/plans/wake_master_plan_cf4d8d1c.plan.md
+++ b/.claude/plans/wake_master_plan_cf4d8d1c.plan.md
@@ -1,0 +1,605 @@
+---
+name: WAKE Master Plan
+overview: A single master plan combining the WAKE technical roadmap (7 phases, ~14 weeks) with a full project management workflow — GitHub as the source of truth, a rigid human+AI collaboration loop, and concrete setup steps before a single line of code is written.
+todos:
+  - id: phase-1
+    content: "Phase -1: GitHub Student Pack, repo creation, Git init, monorepo structure, labels, milestones, Projects board, Issue templates, Notion workspace, ADRs"
+    status: completed
+  - id: phase0
+    content: "Phase 0: kiwix-serve running locally, ZIM verified, Android Studio blank build succeeds"
+    status: completed
+  - id: phase1
+    content: "Phase 1: Python WAKE Gateway Daemon — FastAPI + SQLite + chunker + PyNaCl signing + pytest passing"
+    status: pending
+  - id: phase2
+    content: "Phase 2: Android app — Foreground Service, Room DB, OkHttp client, WebView renderer, end-to-end over local WiFi"
+    status: pending
+  - id: phase3
+    content: "Phase 3: Nearby Connections API — peer discovery, manifest exchange, file transfer, epidemic routing"
+    status: pending
+  - id: phase4
+    content: "Phase 4: PRoPHET routing — routing_table in Room, ProphetRouter.kt, forwarding decision, TTL enforcement"
+    status: pending
+  - id: phase5
+    content: "Phase 5: Security — Android Keystore identity, request signing, relay signature verification"
+    status: pending
+  - id: phase6
+    content: "Phase 6: Pi deployment — systemd services, WiFi hotspot, field test sequence"
+    status: pending
+isProject: false
+---
+
+# WAKE — Master Project Plan
+
+## Roles
+
+- **You (PM + Coder)**: create issues, make architecture decisions, write ADRs, review AI output, commit, merge, test
+- **AI (Cursor)**: implement issues, write tests, follow conventions, never decides architecture alone
+
+The AI executes. You decide.
+
+---
+
+## Phase -1 — Project Infrastructure Setup
+
+**Duration:** 1–2 days | **Hardware:** Laptop only | **Goal:** Everything is in place before a single line of code is written
+
+This phase has no coding. It is pure setup. Complete every step in order. Do not skip steps.
+
+---
+
+### Step 1 — Apply for GitHub Student Developer Pack
+
+The Student Pack gives you GitHub Pro for free, which unlocks private repos with full features, more CI minutes, and other tools used in this project.
+
+1. Go to [education.github.com/pack](https://education.github.com/pack)
+2. Click **"Get student benefits"**
+3. Sign in with your existing GitHub account
+4. When asked to verify, select your school and use your student/university email address
+5. Upload proof of enrollment if prompted (student ID photo or enrollment letter)
+6. Submit — approval can take a few hours to a few days
+
+You can continue with the rest of this phase while waiting for approval.
+
+---
+
+### Step 2 — Create the GitHub Repository
+
+1. Go to [github.com/new](https://github.com/new)
+2. Fill in:
+  - **Repository name:** `wake`
+  - **Description:** `Wireless Asynchronous Knowledge Exchange — Android DTN Mesh`
+  - **Visibility:** Private
+  - Check **"Add a README file"**
+  - Leave everything else as default
+3. Click **"Create repository"**
+
+You now have a remote repository at `https://github.com/YOUR_USERNAME/wake`.
+
+---
+
+### Step 3 — Verify Your SSH Key is Connected to GitHub
+
+This step makes sure your machine can push/pull to GitHub without typing a password every time.
+
+1. Open a terminal and run:
+
+```bash
+   ssh -T git@github.com
+   
+
+```
+
+1. If you see `Hi YOUR_USERNAME! You've successfully authenticated` — you are done, skip to Step 4.
+2. If you see `Permission denied (publickey)`:
+  - Run `cat ~/.ssh/id_ed25519.pub` (or `id_rsa.pub` if that file does not exist)
+  - If neither file exists, run `ssh-keygen -t ed25519 -C "your@email.com"` and press Enter through all prompts
+  - Copy the full output of the `cat` command
+  - Go to [github.com/settings/keys](https://github.com/settings/keys), click **"New SSH key"**, paste it in, click **"Add SSH key"**
+  - Run `ssh -T git@github.com` again to confirm it works
+
+---
+
+### Step 4 — Clone the Repo and Build the Folder Structure
+
+Your workspace already exists at `/home/kush/code/wake/` but it is not a Git repository yet. Clone the GitHub repo and set it up.
+
+1. Open a terminal and run:
+
+```bash
+   cd /home/kush/code
+   git clone git@github.com:YOUR_USERNAME/wake.git wake-src
+   cd wake-src
+   
+
+```
+
+   Replace `YOUR_USERNAME` with your actual GitHub username. This creates a new folder `wake-src` with the cloned repo.
+
+1. Create the full folder structure:
+
+```bash
+   mkdir -p server/tests
+   mkdir -p android
+   mkdir -p docs/decisions
+   mkdir -p .github/ISSUE_TEMPLATE
+   mkdir -p .github/workflows
+   
+
+```
+
+1. Create placeholder files so Git tracks the empty folders:
+
+```bash
+   touch server/tests/.gitkeep
+   touch android/.gitkeep
+   touch docs/decisions/.gitkeep
+   touch .github/workflows/.gitkeep
+   
+
+```
+
+1. Create a `.gitignore` — open Cursor, point it at this folder, and use this prompt:
+  *"Generate a .gitignore for a monorepo with a Python FastAPI server in /server and an Android Kotlin app in /android."*
+   Save the output as `.gitignore` in the root of the project.
+2. Commit and push everything:
+
+```bash
+   git add .
+   git commit -m "chore: initialize monorepo structure"
+   git push origin main
+   
+
+```
+
+---
+
+### Step 5 — Create the `dev` Branch
+
+All coding work happens on `dev`. `main` is only updated at the end of a completed phase.
+
+```bash
+git checkout -b dev
+git push origin dev
+```
+
+Now protect `main` from accidental direct commits:
+
+1. Go to your repo on GitHub → **Settings** → **Branches**
+2. Click **"Add branch protection rule"**
+3. In "Branch name pattern" type `main`
+4. Check **"Require a pull request before merging"**
+5. Click **"Create"**
+
+From now on, nothing can go to `main` without a pull request. This prevents you from accidentally overwriting working code.
+
+---
+
+### Step 6 — Create GitHub Labels
+
+Labels let you filter issues by phase, type, and status on the board.
+
+1. Go to your repo on GitHub → **Issues** tab → **Labels**
+2. Delete all the default labels that GitHub pre-creates (click Edit → Delete on each one)
+3. Create the following labels using the **"New label"** button. For each one: type the name, type the hex color, click Save.
+
+**Phase labels:**
+
+
+| Label name | Color hex |
+| ---------- | --------- |
+| `phase-0`  | `#C5DEF5` |
+| `phase-1`  | `#BFD4F2` |
+| `phase-2`  | `#D4C5F9` |
+| `phase-3`  | `#FEF2C0` |
+| `phase-4`  | `#C2E0C6` |
+| `phase-5`  | `#F9D0C4` |
+| `phase-6`  | `#E4E669` |
+
+
+**Type labels:**
+
+
+| Label name | Color hex |
+| ---------- | --------- |
+| `server`   | `#0075CA` |
+| `android`  | `#3DDC84` |
+| `infra`    | `#E4E669` |
+| `research` | `#D876E3` |
+
+
+**Status labels:**
+
+
+| Label name   | Color hex |
+| ------------ | --------- |
+| `bug`        | `#D73A4A` |
+| `blocked`    | `#B60205` |
+| `adr-needed` | `#FBCA04` |
+
+
+---
+
+### Step 7 — Create GitHub Milestones
+
+Milestones group issues by phase and show a percentage completion bar automatically. You will see exactly how far along each phase is at a glance.
+
+1. Go to your repo → **Issues** tab → **Milestones** → **"New milestone"**
+2. Create each of the following. Calculate the due date by counting weeks from today (today is March 27, 2026):
+
+
+| Milestone title              | Due date       |
+| ---------------------------- | -------------- |
+| `Phase 0 — Setup`            | April 3, 2026  |
+| `Phase 1 — Server Daemon`    | April 24, 2026 |
+| `Phase 2 — Android + WiFi`   | May 15, 2026   |
+| `Phase 3 — Nearby Transport` | June 5, 2026   |
+| `Phase 4 — PRoPHET Routing`  | June 19, 2026  |
+| `Phase 5 — Security`         | June 26, 2026  |
+| `Phase 6 — Pi + Field Test`  | July 10, 2026  |
+
+
+---
+
+### Step 8 — Create GitHub Projects Board
+
+The Projects board is your daily task view — it shows all issues as cards you drag between columns.
+
+1. Go to your repo → **Projects** tab → **"Link a project"** → **"New project"**
+2. Choose the **"Board"** template (not Table or Roadmap)
+3. Name it: `WAKE Development Board`
+4. Click **"Create project"**
+5. You will see 3 default columns (Todo, In Progress, Done). Add two more:
+  - Click **"+ Add column"** on the left side and name it `Backlog`
+  - Click **"+ Add column"** on the right side of Done and name it `Review`
+  - Drag columns so the order is: `Backlog → Todo → In Progress → Review → Done`
+6. Click the **Settings** icon (top right of the board) → **Workflows**
+  - Enable **"Item added to project"** → set it to move new items to `Backlog` automatically
+
+---
+
+### Step 9 — Create Issue Templates
+
+Issue templates are pre-filled forms that appear whenever you click "New issue." They ensure every issue always has the right information.
+
+1. In your terminal:
+
+```bash
+   cd /home/kush/code/wake-src
+   git checkout dev
+   
+
+```
+
+1. Open Cursor, point it at this project folder, and use this prompt:
+  *"Create two GitHub issue template files for a project called WAKE. Save them in .github/ISSUE_TEMPLATE/. The first file is task.md — a template for planned development tasks with fields for: description of the task, what 'done' looks like (acceptance criteria), and checkboxes for: labels assigned, milestone assigned. The second file is bug.md — a template for bugs with fields for: what happened, steps to reproduce it, what you expected to happen, and which phase this was found in."*
+2. Commit and push:
+
+```bash
+   git add .github/ISSUE_TEMPLATE/
+   git commit -m "chore: add GitHub issue templates"
+   git push origin dev
+   
+
+```
+
+---
+
+### Step 10 — Set Up Notion Workspace
+
+Notion is for notes that do not belong in code — weekly logs and decision records.
+
+1. Go to [notion.so](https://notion.so) and log in
+2. Create a new top-level **Page** called `WAKE Project`
+3. Inside it, create two sub-pages:
+  **Project Log** — a database (table) with these columns:
+  - `Week` (number)
+  - `Date` (date)
+  - `What I did` (text)
+  - `What's blocked` (text)
+  - `Decisions made` (text)
+   Add a first row: Week 1, today's date, "Phase -1 setup", leave the rest blank.
+   **ADR Index** — a database (table) with these columns:
+  - `#` (number)
+  - `Title` (text)
+  - `Status` (select: Proposed / Accepted / Superseded)
+  - `Date` (date)
+  - `File path` (text)
+   Leave it empty for now — you will fill it in Step 11.
+
+---
+
+### Step 11 — Write Architecture Decision Records (ADRs)
+
+Before writing any code, document the four major decisions already made for this project. Each decision gets its own markdown file in `docs/decisions/`.
+
+In your terminal:
+
+```bash
+cd /home/kush/code/wake-src
+git checkout dev
+```
+
+Open Cursor and use this prompt for each ADR:
+*"Write an ADR markdown file at docs/decisions/NNN-title.md. Use this format: title as H1, then Status (Accepted), Date, then three H2 sections: Context, Decision, Consequences. The decision to document is: [paste below]"*
+
+Create these four files:
+
+**ADR-001** — `001-nearby-over-ble.md`
+Decision: Use Google Nearby Connections API instead of raw BLE advertising, BLE scanning, GATT server/client, and WifiP2pManager. Reason: eliminates approximately 8 weeks of device-inconsistent low-level transport code. Tradeoff: requires Google Play Services on all Android devices.
+
+**ADR-002** — `002-json-over-cbor.md`
+Decision: Use JSON with base64-encoded payloads for bundle serialization, not CBOR. Reason: JSON is human-readable, debuggable with any tool, and requires no new libraries. Tradeoff: bundles are larger than CBOR. Will revisit if bandwidth becomes a measured problem.
+
+**ADR-003** — `003-laptop-server-first.md`
+Decision: Run the WAKE server daemon on a laptop during Phases 0 through 5. Migrate to Raspberry Pi only in Phase 6. Reason: removes Pi hardware as a development bottleneck; 1 phone plus laptop is sufficient to test all protocol logic.
+
+**ADR-004** — `004-epidemic-routing-first.md`
+Decision: Implement epidemic routing (forward all bundles to all peers) in Phase 3, then upgrade to PRoPHET probabilistic routing in Phase 4. Reason: epidemic routing is trivial to implement and proves the transport layer works. PRoPHET adds complexity only after the foundation is proven.
+
+After all four files are created:
+
+```bash
+git add docs/decisions/
+git commit -m "docs: add ADRs 001-004 for initial architecture decisions"
+git push origin dev
+```
+
+Then open your **ADR Index** in Notion and add all four entries.
+
+---
+
+### Step 12 — Create Phase 0 Issues
+
+The last act of Phase -1 is to pre-populate GitHub with the issues for Phase 0, so your board is ready to go when coding begins.
+
+Go to your repo → **Issues** → **"New issue"** → select the `task` template. Create these 4 issues (matching the Phase 0 summary below):
+
+
+| Title                                                            | Labels               | Milestone       |
+| ---------------------------------------------------------------- | -------------------- | --------------- |
+| `Install kiwix-serve and download Wikipedia Top Mini ZIM`        | `phase-0`, `server`  | Phase 0 — Setup |
+| `Verify kiwix-serve search API returns HTML in browser`          | `phase-0`, `server`  | Phase 0 — Setup |
+| `Create Android Studio project (Kotlin + Jetpack Compose, verify build)` | `phase-0`, `android` | Phase 0 — Setup |
+| `Write ADRs 001–004`                                             | `phase-0`, `infra`   | Phase 0 — Setup |
+
+
+After creating them, go to your GitHub Projects board. All 4 issues should appear in **Backlog**. Drag them all to **Todo**. Phase -1 is complete.
+
+---
+
+### Phase -1 Done When
+
+- GitHub Student Developer Pack applied for
+- Repo exists at `github.com/YOUR_USERNAME/wake`
+- SSH connection to GitHub works (`ssh -T git@github.com` succeeds)
+- Folder structure committed and pushed to `main`
+- `dev` branch exists and is pushed to GitHub
+- `main` branch is protected (requires PRs to merge)
+- All 14 labels created in GitHub (7 phase + 4 type + 3 status)
+- All 7 milestones created with due dates
+- GitHub Projects board exists with 5 columns and auto-add enabled
+- Issue templates exist at `.github/ISSUE_TEMPLATE/task.md` and `bug.md`
+- Notion workspace has Project Log and ADR Index pages with first entries
+- 4 ADR files committed to `docs/decisions/` and pushed to `dev`
+- 4 Phase 0 issues created in GitHub and visible under "Todo" on the board
+
+---
+
+## Human + AI Collaboration Protocol
+
+This is the loop you run for every issue:
+
+```
+1. You open GitHub, pick the next issue from "Todo" on the board
+2. You create a feature branch: git checkout -b feature/phase-X-name dev
+3. You open Cursor and say:
+   "I am working on issue #N: [paste title + description].
+    Current relevant files: [list them]. Implement this."
+4. AI implements. You review every file it touches.
+5. If something looks wrong, ask AI to explain before accepting.
+6. When satisfied: git add + git commit (you write the commit message)
+7. Push branch, open PR to dev, close the issue in the PR description
+8. Merge PR. Repeat.
+```
+
+**Rules for AI sessions:**
+
+- Start every session by telling AI the current issue number and phase
+- One issue per session where possible — don't mix concerns
+- Never let AI commit directly; you always commit
+- If AI makes an architecture decision you didn't ask for, stop and write an ADR before continuing
+- At the end of a phase, do a session with AI specifically to write tests for that phase
+
+---
+
+## Architecture Decision Records
+
+Every time a significant technical choice is made, create `docs/decisions/NNN-short-title.md`:
+
+```markdown
+# ADR-001: Use Google Nearby Connections API instead of raw BLE + WiFi Direct
+
+Status: Accepted | Date: YYYY-MM-DD
+
+## Context
+[Why this decision was needed]
+
+## Decision
+[What was decided]
+
+## Consequences
+[What this enables and what it constrains]
+```
+
+Decisions that already need ADRs before Phase 0 starts:
+
+- ADR-001: Nearby Connections API over raw BLE/WiFi Direct
+- ADR-002: JSON bundles over CBOR (for now)
+- ADR-003: Laptop server during development, Pi deferred to Phase 6
+- ADR-004: Epidemic routing first, PRoPHET as Phase 4 upgrade
+
+---
+
+## Weekly Rhythm
+
+**Monday (15 min):**
+
+- Open GitHub Projects board
+- Move any stale "In Progress" issues back to "Todo"
+- Pick 2–3 issues for the week, move to "In Progress"
+- Write one line in Notion Project Log: this week's goal
+
+**Friday (10 min):**
+
+- Close completed issues
+- Check milestone % complete (GitHub shows this automatically)
+- If phase milestone is 100%: open PR from `dev` → `main`, write phase summary in PR description, merge
+
+---
+
+## Phase 0 — Environment Setup
+
+**Duration:** Week 1 | **Hardware:** Laptop only | **AI sessions:** 0 (manual setup)
+
+**Issues to create (label: `phase-0`, milestone: Phase 0):**
+
+- `#1` Install kiwix-serve and download Simple English Wikipedia ZIM (~80 MB)
+- `#2` Verify kiwix-serve search API returns HTML in browser
+- `#3` Create Android Studio project (blank Kotlin + Jetpack Compose, verify build)
+- `#4` Write ADRs 001–004
+
+**Done when:** Browser shows a kiwix article. Android Studio builds a blank app. Four ADR files exist in `docs/decisions/`.
+
+---
+
+## Phase 1 — Python Server Daemon
+
+**Duration:** Weeks 1–4 | **Hardware:** Laptop only | **AI sessions:** 4–6
+
+**Issues to create (label: `phase-1 server`, milestone: Phase 1):**
+
+- `#5` Set up FastAPI project skeleton with uvicorn, health check endpoint, `requirements.txt`
+- `#6` Define bundle JSON schema (request + response structs as Pydantic models)
+- `#7` Implement SQLite schema with aiosqlite: `inbound_requests`, `outbound_bundles`, `seen_bundle_ids`
+- `#8` Implement chunker: split response payload into ~100 KB numbered chunks
+- `#9` Implement PyNaCl Ed25519 keypair generation and bundle signing
+- `#10` Implement kiwix proxy + HTTP endpoints: `POST /request`, `GET /pending`, `GET /bundle/{id}`, `GET /pubkey`. Proxy logic: if `query_string` starts with `/` treat as article path and call `GET {path}` on kiwix-serve; otherwise treat as search term and call `GET /search?pattern={query_string}`. Return HTML response as chunked bundle payload.
+- `#11` Write pytest tests for: bundle create/serialize, chunker, kiwix proxy routing (search vs article path), signature verify/fail
+
+**Key technical decisions:**
+
+- Bundle format: JSON + base64 payload (not CBOR — readable and debuggable)
+- Request bundle fields: `{node_id, query_id, query_string, timestamp, ttl_seconds, hop_count, signature}`
+- Response bundle fields: `{server_id, query_id, chunk_index, total_chunks, content_type, payload_b64, sha256, signature}`
+- `node_id` is a UUID for Phase 1 testing; Android Keystore identity is deferred to Phase 5
+- Two request types distinguished by `query_string` prefix: plain text = search, `/A/...` = article fetch
+
+**Done when:** `pytest server/tests/` passes. Sending a `POST /request` with a plain search term returns search results HTML chunks. Sending one with `/A/Water` returns article HTML chunks.
+
+---
+
+## Phase 2 — Android App + Direct Server Link
+
+**Duration:** Weeks 3–7 | **Hardware:** 1 phone + laptop on same WiFi | **AI sessions:** 6–8
+
+**Issues to create (label: `phase-2 android`, milestone: Phase 2):**
+
+- `#12` Create Android Foreground Service skeleton (persistent notification, lifecycle)
+- `#13` Define Room DB schema: `bundles` table + `seen_ids` table
+- `#14` Implement BundleStoreManager: write/read/evict bundles, LRU policy at 500 MB cap
+- `#15` Implement OkHttp client: POST request bundle, poll `GET /pending`, fetch chunks
+- `#16` Implement chunk reassembly: detect when all chunks for a `query_id` are present, merge bytes
+- `#17` Build UI: Search screen (text field + results list rendered from search HTML), Status screen (storage, last sync)
+- `#18` Build Result screen: WebView rendering reassembled article HTML; override `shouldOverrideUrlLoading` to intercept `/A/...` link taps and fire a new WAKE bundle request instead of navigating directly
+- `#19` Integrate Google Tink: verify server Ed25519 signatures before caching any bundle
+
+**Done when:** Phone on same WiFi as laptop — type a query, search results render, tap a result, full article renders in WebView. A tampered bundle (manually edited) is rejected.
+
+---
+
+## Phase 3 — Nearby Connections API Transport
+
+**Duration:** Weeks 6–10 | **Hardware:** 2 phones | **AI sessions:** 4–6
+
+**Issues to create (label: `phase-3 android`, milestone: Phase 3):**
+
+- `#20` Add `play-services-nearby:19.1.0` dependency, configure permissions in manifest
+- `#21` Implement Nearby advertising + discovery with WAKE service ID `"com.wake.dtn"`
+- `#22` Implement ConnectionLifecycleCallback and PayloadCallback
+- `#23` Implement manifest exchange: serialize bundle list as `Payload.fromBytes`, parse received manifest
+- `#24` Implement bundle transfer: diff manifests, send missing bundles as `Payload.fromFile`
+- `#25` Implement epidemic routing: forward all held bundles to every new peer; check `seen_ids` before forwarding
+
+**What this replaces:** All raw BLE and WiFi Direct code from the original roadmap.
+
+**Done when:** Phone A holds a bundle. Phone B comes within range. Phone B receives the bundle via Nearby. Verified in Room DB on phone B.
+
+---
+
+## Phase 4 — PRoPHET Routing Upgrade
+
+**Duration:** Weeks 9–12 | **Hardware:** 2 phones | **AI sessions:** 3–4
+
+**Issues to create (label: `phase-4 android`, milestone: Phase 4):**
+
+- `#26` Add `routing_table` to Room: `(node_id, destination_id, delivery_prob REAL, last_updated INTEGER)`
+- `#27` Implement ProphetRouter.kt: direct contact update, transitivity update, aging formulas
+- `#28` Add routing table exchange to Nearby manifest exchange step
+- `#29` Replace epidemic forwarding decision with PRoPHET decision: only forward if `neighbor.P > self.P`
+- `#30` Implement TTL enforcement: drop bundles where `ttl_expires_at < now()`
+
+**Formulas (implement exactly as specified):**
+
+- Direct contact: `P(A→B) = P_old + (1 - P_old) × 0.75`
+- Transitivity: `P(A→C) = P_old(A→C) + (1 - P_old(A→C)) × P(A→B) × P(B→C) × 0.25`
+- Aging: `P = P_old × 0.98^k`
+- Server always advertises `P = 1.0` to itself
+
+**Done when:** Relay phone only forwards a bundle to a peer when logged `P(peer→server) > P(self→server)`. Bundles past TTL are dropped before forwarding.
+
+---
+
+## Phase 5 — Security Hardening
+
+**Duration:** Weeks 11–13 | **Hardware:** 1 phone | **AI sessions:** 2–3
+
+**Issues to create (label: `phase-5 android server`, milestone: Phase 5):**
+
+- `#31` Android Keystore: generate Ed25519 keypair on first launch, derive node_id from public key
+- `#32` Sign outbound request bundles with Keystore key; server verifies on receipt
+- `#33` Relay verification: verify server signature before caching any response bundle
+- `#34` (Optional) Tink HybridEncrypt: encrypt query_string in request with server X25519 public key
+
+**Done when:** Relay rejects a response bundle with a forged/missing server signature. Request bundles are signed with device key that server can verify.
+
+---
+
+## Phase 6 — Pi Deployment + Field Testing
+
+**Duration:** Weeks 12–14 | **Hardware:** 1 phone + Raspberry Pi | **AI sessions:** 2–3
+
+**Issues to create (label: `phase-6 infra`, milestone: Phase 6):**
+
+- `#35` Deploy WAKE daemon + kiwix-serve on Pi as systemd services
+- `#36` Configure Pi WiFi hotspot: `hostapd` + `dnsmasq`, SSID `WAKE-Server`, IP `192.168.4.1`
+- `#37` Update Android app: configurable server IP (not hardcoded to laptop)
+- `#38` Battery optimization: Nearby `STRATEGY_CLUSTER` when idle
+- `#39` Field test: direct phone→Pi query
+- `#40` Field test: phone out of range, then return, deferred delivery
+- `#41` Field test: 2-phone relay path (need to borrow 2nd phone)
+
+**Done when:** Issue #40 passes — a query submitted out of Pi range is delivered when the phone walks back into Pi hotspot range.
+
+---
+
+## Hardware Requirements by Phase
+
+
+| Phase | Minimum Hardware                                       |
+| ----- | ------------------------------------------------------ |
+| 0–1   | Laptop only                                            |
+| 2     | Laptop + 1 Android phone                               |
+| 3–4   | Laptop + 2 Android phones                              |
+| 5     | Laptop + 1 phone                                       |
+| 6     | Raspberry Pi + 1 phone (2 phones for final relay test) |

--- a/.claude/plans/wake_revised_roadmap_8cbd3923.plan.md
+++ b/.claude/plans/wake_revised_roadmap_8cbd3923.plan.md
@@ -1,0 +1,206 @@
+---
+name: WAKE Revised Roadmap
+overview: Rebuild the WAKE DTN roadmap around existing solutions — primarily Google Nearby Connections API (replaces all BLE + WiFi Direct code) and kiwix-serve (content layer already built) — reducing scope from 30 weeks to ~14 weeks. Phases 0–2 need 1 phone + laptop; Phase 3+ needs 2 phones.
+todos:
+  - id: phase0
+    content: "Phase 0: Install kiwix-serve, download small ZIM, verify search API, set up Android Studio"
+    status: completed
+  - id: phase1
+    content: "Phase 1: Build Python WAKE Gateway Daemon (FastAPI + kiwix-serve + SQLite + PyNaCl signing)"
+    status: pending
+  - id: phase2
+    content: "Phase 2: Build Android app with Room, OkHttp HTTP client, Tink verification, WebView renderer — end-to-end over local WiFi"
+    status: pending
+  - id: phase3
+    content: "Phase 3: Add Google Nearby Connections API, implement bundle manifest exchange and file transfer, epidemic routing"
+    status: pending
+  - id: phase4
+    content: "Phase 4: Upgrade to PRoPHET routing — routing table in Room, delivery probability updates, forwarding decision logic"
+    status: pending
+  - id: phase5
+    content: "Phase 5: Security hardening — Android Keystore node identity, request signing, relay verification"
+    status: pending
+  - id: phase6
+    content: "Phase 6: Deploy to Raspberry Pi (systemd + hostapd WiFi hotspot), full field test sequence"
+    status: pending
+isProject: false
+---
+
+# WAKE — Revised Project Roadmap
+
+## Core Philosophy Change
+
+The original roadmap builds BLE advertising, BLE scanning, WiFi Direct group negotiation, and GATT servers from scratch — 4 of the 9 phases. The new roadmap replaces all of that with a single library: **Google Nearby Connections API**. Everything else (kiwix-serve, Room, Tink, FastAPI) stays the same or gets simplified.
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+    subgraph phone_side [Phone Side]
+        ClientPhone["Client Phone\n(WAKE app)"]
+        RelayPhone["Relay Phone\n(WAKE app)"]
+    end
+    subgraph server_side [Server Side]
+        WAKEDaemon["WAKE Daemon\n(FastAPI)"]
+        kiwix["kiwix-serve\n(ZIM content)"]
+    end
+
+    ClientPhone -->|"Nearby Connections API"| RelayPhone
+    RelayPhone -->|"HTTP over WiFi hotspot"| WAKEDaemon
+    WAKEDaemon -->|"localhost HTTP"| kiwix
+```
+
+
+
+- **Phone-to-phone**: Nearby Connections API (auto-selects WiFi Direct / BLE / BT Classic)
+- **Phone-to-server**: HTTP over local WiFi or Pi hotspot (no Nearby needed)
+- **Server**: Python FastAPI + kiwix-serve on laptop (dev) → Pi (production)
+
+---
+
+## Phase 0 — Environment Setup (Week 1)
+
+**Needs: laptop only**
+
+- Install kiwix-serve; download **English Wikipedia Top Mini** ZIM (`wikipedia_en_top_mini_2026-03.zim`, ~315 MB). Avoid `wikipedia_en_simple_all_mini` — broken builds.
+- Verify kiwix-serve REST API: `GET /search?pattern=...` returns search results HTML; articles at `GET /A/Article_Name`
+- Install Android Studio, create a blank Kotlin + Jetpack Compose project, verify build succeeds
+- Goal: see kiwix content in a browser by end of week
+
+**Key files/tools:** `kiwix-serve`, Android Studio, Python 3.11+
+
+---
+
+## Phase 1 — Python Server Daemon (Weeks 1–4)
+
+**Needs: laptop only**
+
+Build the **WAKE Gateway Daemon** — a FastAPI app that sits in front of kiwix-serve and speaks the WAKE bundle protocol.
+
+- **Bundle format**: Start with **JSON + base64** (not CBOR). Readable, debuggable, no new libraries. Migrate to CBOR only if size becomes a real problem.
+  - Request bundle: `{node_id, query_id, query_string, timestamp, ttl_seconds, hop_count, signature}`
+  - Response bundle: `{server_id, query_id, chunk_index, total_chunks, content_type, payload_b64, sha256, signature}`
+- **kiwix proxy logic** (two request types, same bundle protocol):
+  - **Search**: `query_string` is a search term → daemon calls `GET /search?pattern={query_string}` on kiwix-serve → returns search results HTML as the bundle payload. Results contain article links of the form `/A/Article_Title`.
+  - **Article fetch**: `query_string` is a kiwix article path (e.g. `/A/Water`) → daemon calls `GET /A/Water` on kiwix-serve → returns full article HTML as the bundle payload.
+  - The daemon distinguishes the two by checking whether `query_string` starts with `/` (article path) or not (search term).
+- **SQLite queue** (`aiosqlite`): tables for `inbound_requests`, `outbound_bundles`, `seen_bundle_ids`
+- **Chunker**: split large HTML/image responses into ~100 KB chunks, each chunk is a separate JSON bundle file
+- **Signing**: `PyNaCl` Ed25519 keypair generated once, stored on disk. Sign every outbound bundle. Expose public key at `GET /pubkey`
+- **HTTP endpoints** (for phones to call over WiFi):
+  - `POST /request` — receive a request bundle from a phone
+  - `GET /pending?node_id=...` — phone polls for response bundles addressed to it
+  - `GET /bundle/{bundle_id}` — fetch a specific bundle file
+
+**Key libraries:** `fastapi`, `uvicorn`, `aiosqlite`, `pynacl`, `httpx`
+
+**Phase 1 notes:**
+- Project skeleton includes `requirements.txt` with pinned versions
+- `node_id` is a UUID for Phase 1 testing; Android Keystore identity deferred to Phase 5
+- Two request types distinguished by `query_string` prefix: plain text = search, `/A/...` path = article fetch
+
+---
+
+## Phase 2 — Android App + Direct Server Link (Weeks 3–7)
+
+**Needs: 1 phone + laptop on same WiFi**
+
+Build the Android app and get a full end-to-end working — search query flows from phone to server over local WiFi, content comes back and renders. No DTN yet.
+
+- **Foreground Service**: keeps the app alive; handles all network operations. Mandatory for background operation
+- **Room DB schema**: `bundles` table (id, query_id, type, chunk_idx, total_chunks, payload_path, ttl_expires_at, status), `seen_ids` table
+- **Bundle store manager**: Kotlin class; writes payloads as files in `filesDir`, metadata to Room; LRU eviction when storage cap exceeded (default 500 MB)
+- **HTTP client** (OkHttp): phone POSTs a request bundle to `{server_ip}/request`, then polls `GET /pending?node_id=...` every 10s until all chunks arrive
+- **Chunk reassembly**: when all `total_chunks` are present in Room for a `query_id`, reassemble payload bytes in chunk_index order
+- **UI (Jetpack Compose)**:
+  - Search screen: text field + search button + results list rendered from search HTML
+  - Status screen: storage used, last sync time
+  - Result screen: `WebView` rendering reassembled article HTML. Override `shouldOverrideUrlLoading` to intercept `/A/...` link taps and fire a new WAKE bundle request instead of navigating directly to kiwix-serve.
+- **Signing verification**: use `Tink` (Android) to verify Ed25519 signatures from server before accepting any bundle
+
+**Key libraries:** `Room`, `OkHttp`, `Jetpack Compose`, `Google Tink`
+
+---
+
+## Phase 3 — Nearby Connections API Transport (Weeks 6–10)
+
+**Needs: 2 phones** (borrow one for this phase)
+
+Replace the WiFi HTTP polling with the Nearby Connections API for phone-to-phone bundle exchange. This is the entire BLE + WiFi Direct problem solved with one dependency.
+
+**Add to `build.gradle`:**
+
+```kotlin
+implementation("com.google.android.gms:play-services-nearby:19.1.0")
+```
+
+- **Discovery**: call `Nearby.getConnectionsClient(context).startAdvertising(...)` and `startDiscovery(...)` with a WAKE service ID string (`"com.wake.dtn"`). Nearby handles BLE advertising and scanning automatically
+- **Connection lifecycle**: implement `ConnectionLifecycleCallback` — `onConnectionInitiated`, `onConnectionResult`, `onDisconnected`. Accept all WAKE peer connections automatically
+- **Manifest exchange**: on connection, send your bundle manifest (list of `{query_id, chunk_index}` you hold) as a `Payload.fromBytes(...)`. Receive theirs
+- **Bundle transfer**: diff the two manifests, send missing bundles as `Payload.fromFile(...)` (Nearby streams the file directly — no memory pressure)
+- **Epidemic routing** (Phase 3a, start here): forward every bundle you hold to every new peer you meet. Simple flood-fill. This is your default routing mode
+- **Deduplication**: check `seen_ids` Room table before forwarding; insert after forwarding
+
+**What Nearby replaces from the original roadmap:**
+
+- All of Phase 4 (BLE Advertiser, BLE Scanner, GATT server/client)
+- All of Phase 5 (WifiP2pManager, NanoHTTPD transfer server, OkHttp transfer client, session lifecycle, WiFi disconnect handling)
+
+---
+
+## Phase 4 — PRoPHET Routing Upgrade (Weeks 9–12)
+
+**Needs: 2 phones**
+
+Upgrade from epidemic routing (flood-fill) to **PRoPHET routing** — only forward a bundle to a neighbor if they have higher delivery probability to the destination than you do.
+
+- Add `routing_table` to Room: `(node_id, destination_id, delivery_prob REAL, last_updated INTEGER)`
+- On each Nearby connection: exchange routing tables as part of the manifest exchange
+- **PRoPHET update formulas** (implement in a ~200-line `ProphetRouter.kt`):
+  - Direct contact: `P(A→B) = P_old + (1 - P_old) × 0.75`
+  - Transitivity: `P(A→C) = P_old(A→C) + (1 - P_old(A→C)) × P(A→B) × P(B→C) × 0.25`
+  - Aging: `P = P_old × 0.98^k` (k = time units since last update)
+- **Forwarding decision**: only push bundle to neighbor if `neighbor.P(→dst) > self.P(→dst)`. Server advertises `P = 1.0` to itself
+- TTL enforcement: check `ttl_expires_at` before forwarding; drop expired bundles
+
+---
+
+## Phase 5 — Security Hardening (Weeks 11–13)
+
+**Needs: 1 phone**
+
+Most of this is already stubbed in Phase 2 (Tink + signing). Harden and complete it.
+
+- **Node identity**: on first launch, generate Ed25519 keypair in **Android Keystore** (hardware-backed). The public key IS the node_id. Never leaves the secure enclave
+- **Request signing**: client signs outbound request bundles with its Keystore key. Server verifies before processing
+- **Relay verification**: relay nodes verify server signature before caching a response bundle — prevents content poisoning
+- **Optional (if privacy matters)**: encrypt request payload with server's X25519 public key using Tink's `HybridEncrypt`. Only the server can read the query string
+
+---
+
+## Phase 6 — Pi Deployment + Field Testing (Weeks 12–14)
+
+**Needs: 1 phone + Raspberry Pi**
+
+Move the server from laptop to Pi. Test the full DTN path.
+
+- Deploy WAKE daemon + kiwix-serve on Pi as systemd services
+- Configure Pi as a **WiFi hotspot** (`hostapd` + `dnsmasq`): Pi broadcasts SSID `WAKE-Server`, phones connect to it when physically near
+- Phone-to-Pi: same HTTP polling protocol from Phase 2, just pointed at Pi IP (`192.168.4.1`)
+- **Field test sequence**:
+  1. Phone directly connected to Pi hotspot → query works end-to-end
+  2. Phone out of Pi range → submit query → walk back into range → response delivered
+  3. Two phones: Client submits query, Relay phone carries it to Pi, response routed back (need 2 phones here)
+- Battery optimization: switch Nearby to `STRATEGY_CLUSTER` (low-power periodic scan) when idle; `STRATEGY_P2P_STAR` only when actively exchanging
+
+---
+
+## What Was Eliminated vs. Original
+
+- Phase 4 (BLE from scratch) — **replaced by Nearby Connections API**
+- Phase 5 (WiFi Direct from scratch) — **replaced by Nearby Connections API**
+- CBOR serialization — **replaced by JSON** (simpler, revisit if bandwidth matters)
+- GATT server for manifest exchange — **replaced by Nearby `Payload.fromBytes`**
+- Pi-first constraint — **replaced by laptop-first** (Pi in final phase only)
+- 3-phone requirement for first test — **2 phones, deferred to Phase 3**
+- ~16 weeks of original scope — **eliminated**

--- a/.claude/rules/android.md
+++ b/.claude/rules/android.md
@@ -1,0 +1,50 @@
+---
+description: Kotlin and Android conventions for the WAKE Android app
+paths:
+  - "android/**/*.kt"
+  - "android/**/*.kts"
+---
+
+# Android Rules
+
+## Stack
+
+Kotlin, Jetpack Compose (UI), Room v3 (local DB), OkHttp (HTTP), Google Nearby Connections API (Phase 3+, `play-services-nearby:19.1.0`), Google Tink (Ed25519 signature verification). Foreground Service for always-on relay.
+
+## Code Style
+
+- `val` over `var`. Data classes for models. `when` over `if-else` chains.
+- Coroutines for all async work: `Dispatchers.IO` for disk/network, `Dispatchers.Main` for UI.
+- ViewModels: `<Screen>ViewModel`. Composables: `<Screen>Screen`. Keep composables small.
+- Business logic belongs in ViewModel or Repository, never in Composables.
+
+## Architecture
+
+MVVM + Foreground Service:
+- `data/` — Room entities, DAOs, `BundleStoreManager` (payload files in `context.filesDir`, LRU eviction at 500 MB cap)
+- `service/` — `WakeService` (owns coroutine scope), `WakeHttpClient`, `ServerSyncManager`
+- `ui/` — Compose screens and ViewModels
+
+## Nearby Connections
+
+- Service ID: `"com.wake.dtn"` — must match exactly on all peers.
+- `Strategy.P2P_CLUSTER` for multi-peer mesh topology.
+- Connection callbacks go in a dedicated `NearbyConnectionManager` class, not scattered in Activities.
+- Always disconnect after bundle exchange completes.
+
+## Bundle Storage
+
+- Payload bytes: files in `context.filesDir`, named `{query_id}_{chunk_index}.bundle`.
+- Metadata: Room `bundles` table. `seen_ids` table for deduplication.
+- Eviction: TTL-expired first, then LRU when total storage exceeds 500 MB.
+
+## Required Permissions
+
+`ACCESS_FINE_LOCATION`, `BLUETOOTH_SCAN`, `BLUETOOTH_ADVERTISE`, `BLUETOOTH_CONNECT`, `NEARBY_WIFI_DEVICES` (API 33+), `POST_NOTIFICATIONS` (API 33+).
+
+## Testing
+
+- Always write `androidTest/` tests alongside implementation, mirroring the feature's package structure.
+- Use `@RunWith(AndroidJUnit4::class)`. Use `ServiceTestRule` for `WakeService` tests.
+- Physical device required — emulators cannot run Nearby or BLE.
+- Source directory path must exactly match the Kotlin `package` declaration or UTP finds 0 tests.

--- a/.claude/rules/server.md
+++ b/.claude/rules/server.md
@@ -1,0 +1,30 @@
+---
+description: Python and FastAPI conventions for the WAKE server daemon
+paths:
+  - "server/**/*.py"
+---
+
+# Server Rules
+
+## Stack
+
+Python 3.11+, FastAPI, uvicorn, aiosqlite, PyNaCl, httpx. SQLite only (no Postgres, no Redis). kiwix-serve is a separate process on `localhost:8888` — call it via the shared `httpx.AsyncClient` on `app.state.kiwix_client`.
+
+## Code Style
+
+- `async def` for all endpoint handlers and DB operations.
+- Type-annotate all function signatures; use `pydantic` models for request/response schemas.
+- `pathlib.Path` over `os.path` for all file paths.
+- Imports: stdlib → third-party → local. One blank line between groups. No wildcard imports.
+
+## Error Handling
+
+- Never swallow exceptions silently. Use the `logging` module at the appropriate level.
+- HTTP status codes: 400 bad input, 404 missing bundle, 502 kiwix-serve error, 500 internal.
+- Use `HTTPException(status_code=..., detail="...")` with a descriptive detail string.
+
+## Testing
+
+- `pytest` + `pytest-asyncio` for async tests. Files live in `server/tests/test_<module>.py`.
+- Use `httpx.AsyncClient` with FastAPI's `TestClient` for endpoint tests.
+- Every new module needs at least one corresponding test file.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pytest server/tests/*)",
+      "Bash(cd android && ./gradlew assembleDebug)",
+      "Bash(cd android && ./gradlew connectedDebugAndroidTest*)",
+      "Bash(kiwix-serve*)",
+      "Bash(uvicorn*)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)"
+    ],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ Thumbs.db
 *.swo
 *~
 
+# --- Claude Code (local machine settings only) ---
+.claude/settings.local.json
+.claude/projects/
+
 # --- Python (server/) ---
 __pycache__/
 *.py[cod]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Identity
+
+WAKE (Wireless Asynchronous Knowledge Exchange) — an Android DTN (Delay-Tolerant Network) mesh that delivers offline educational content from a kiwix-serve server to Android phones via store-and-forward relay.
+
+## Architecture
+
+- **Server**: Python FastAPI daemon wrapping kiwix-serve (runs on laptop, migrates to Raspberry Pi in Phase 6).
+- **Android app**: Kotlin + Jetpack Compose. Foreground Service owns all network/storage ops. OkHttp for server HTTP; Google Nearby Connections API (Phase 3+) for phone-to-phone transport.
+- **Bundle protocol**: JSON + base64 payloads. Two request types distinguished by `query_string` prefix: plain text = search (`GET /search?pattern=...`), `/A/...` = article fetch.
+  - Request fields: `node_id, query_id, query_string, timestamp, ttl_seconds, hop_count, signature`
+  - Response fields: `server_id, query_id, chunk_index, total_chunks, content_type, payload_b64, sha256, signature`
+- **Routing**: Epidemic flood-fill (Phase 3) → PRoPHET probabilistic routing (Phase 4).
+- **Security**: PyNaCl Ed25519 signing on server; Google Tink verification on Android. Android Keystore identity is Phase 5 (issue #31).
+
+## Branching & Commits
+
+- `main` — stable; merged only at phase completion via PR. Never commit directly.
+- `dev` — integration branch; all feature branches merge here.
+- `feature/phase-X-description` — one branch per issue.
+
+Conventional Commits: `<type>(<scope>): <imperative description>`
+Types: `feat`, `fix`, `test`, `docs`, `refactor`, `chore`
+Scopes: `server`, `android`, `bundle`, `routing`, `security`, `ci`
+
+## Server
+
+```bash
+# Start kiwix-serve (ZIM lives outside the repo)
+kiwix-serve --port 8888 ~/zim/wikipedia_en_top_mini_2026-03.zim
+
+# Install dependencies
+cd server && pip install -r requirements.txt
+
+# Start WAKE daemon
+cd server && uvicorn main:app --reload --port 8000
+
+# Run all tests
+pytest server/tests/
+
+# Run one test file or one test
+pytest server/tests/test_chunker.py
+pytest server/tests/test_signing.py::test_sign_and_verify
+```
+
+`server/conftest.py` puts `server/` on `sys.path` — no package install needed for tests.
+
+## Android
+
+```bash
+cd android
+
+# Build
+./gradlew assembleDebug
+
+# All instrumented tests (requires physical device)
+./gradlew connectedDebugAndroidTest
+
+# Single test class
+./gradlew connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.wake.dtn.data.BundleDaoTest
+
+# Single package
+./gradlew connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.package=com.wake.dtn.service
+```
+
+Emulators cannot run Nearby Connections or BLE features — always use a physical device.
+
+## Constraints
+
+- Never introduce a new library or dependency without asking.
+- Never change project structure without asking.
+- If a task requires an architecture decision, flag it and suggest writing an ADR in `docs/decisions/` rather than deciding unilaterally.
+- Do not migrate bundles from JSON+base64 to CBOR unless explicitly asked.
+- `node_id` is a random UUID for Phases 1–4; Keystore identity is Phase 5.
+
+## Learned Corrections
+
+### 2026-03-28 — Source directory must match Kotlin package declaration
+Android's UTP test runner derives the `-e package` filter from the source *directory path*. If `src/main/java/com/wake/dtm/` is the path but `package com.wake.dtn` is declared, UTP passes the wrong package and finds 0 tests. The directory path and package declaration must be identical.
+
+### 2026-03-28 — Always write Android instrumented tests alongside implementation
+When implementing Android features, always write `androidTest/` tests that mirror the feature structure (`androidTest/service/` for Services, etc.). Use `@RunWith(AndroidJUnit4::class)` and `ServiceTestRule` for service tests. Do this by default, without being asked.
+
+## Plans
+
+- @.claude/plans/wake_revised_roadmap_8cbd3923.plan.md — active technical reference: per-phase decisions, component responsibilities, done criteria
+- @.claude/plans/wake_master_plan_cf4d8d1c.plan.md — GitHub issue list, collaboration protocol, weekly rhythm

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
 }
 
@@ -70,4 +71,7 @@ dependencies {
     ksp(libs.androidx.room.compiler)
     androidTestImplementation(libs.androidx.room.testing)
     androidTestImplementation(libs.kotlinx.coroutines.test)
+    implementation(libs.okhttp)
+    implementation(libs.kotlinx.serialization.json)
+    androidTestImplementation(libs.okhttp.mockwebserver)
 }

--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleDaoTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleDaoTest.kt
@@ -28,7 +28,9 @@ class BundleDaoTest {
     }
 
     @After
-    fun closeDb() = db.close()
+    fun closeDb() {
+        if (::db.isInitialized) runCatching { db.close() }
+    }
 
     // --- helpers ---
 

--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
@@ -47,8 +47,8 @@ class BundleStoreManagerTest {
 
     @After
     fun tearDown() {
-        db.close()
-        testFilesDir.deleteRecursively()
+        if (::db.isInitialized) runCatching { db.close() }
+        if (::testFilesDir.isInitialized) testFilesDir.deleteRecursively()
     }
 
     // --- helpers ---

--- a/android/app/src/androidTest/java/com/wake/dtn/data/SeenIdDaoTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/SeenIdDaoTest.kt
@@ -27,7 +27,9 @@ class SeenIdDaoTest {
     }
 
     @After
-    fun closeDb() = db.close()
+    fun closeDb() {
+        if (::db.isInitialized) runCatching { db.close() }
+    }
 
     @Test
     fun existsReturnsFalseBeforeInsert() = runTest {

--- a/android/app/src/androidTest/java/com/wake/dtn/service/ServerSyncManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/ServerSyncManagerTest.kt
@@ -1,0 +1,161 @@
+package com.wake.dtn.service
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.wake.dtn.data.BundleStoreManager
+import com.wake.dtn.data.BundleType
+import com.wake.dtn.data.WakeDatabase
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class ServerSyncManagerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var db: WakeDatabase
+    private lateinit var storeManager: BundleStoreManager
+    private lateinit var syncManager: ServerSyncManager
+    private lateinit var testFilesDir: File
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+
+        db = Room.inMemoryDatabaseBuilder(context, WakeDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        testFilesDir = File(context.filesDir, "test_sync_manager").also { it.mkdirs() }
+
+        storeManager = BundleStoreManager(
+            context = object : android.content.ContextWrapper(context) {
+                override fun getFilesDir(): File = testFilesDir
+            },
+            dao = db.bundleDao(),
+        )
+
+        syncManager = ServerSyncManager(
+            httpClient = WakeHttpClient(baseUrl = server.url("/").toString().trimEnd('/')),
+            storeManager = storeManager,
+            nodeId = "test-node-id",
+        )
+    }
+
+    @After
+    fun tearDown() {
+        // JUnit runs @After even when @Before threw — guard every lateinit.
+        if (::db.isInitialized) runCatching { db.close() }
+        if (::testFilesDir.isInitialized) testFilesDir.deleteRecursively()
+        if (::server.isInitialized) runCatching { server.shutdown() }
+    }
+
+    // --- helpers ---
+
+    private fun chunkJson(
+        queryId: String = "qid-1",
+        chunkIndex: Int = 0,
+        totalChunks: Int = 1,
+        payloadB64: String = "aGVsbG8=",
+        sha256: String = "deadbeef",
+    ) = """{"server_id":"wake-server-01","query_id":"$queryId","chunk_index":$chunkIndex,""" +
+        """"total_chunks":$totalChunks,"content_type":"text/html","payload_b64":"$payloadB64",""" +
+        """"sha256":"$sha256","signature":null}"""
+
+    private fun chunksJson(vararg chunks: String) = "[${chunks.joinToString(",")}]"
+
+    private fun pendingJson(vararg ids: String) =
+        """{"pending_query_ids":[${ids.joinToString(",") { "\"$it\"" }}]}"""
+
+    // --- submitRequest ---
+
+    @Test
+    fun submitRequest_sendsPostWithCorrectBody() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        syncManager.submitRequest("qid-1", "water cycle")
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertTrue("path must end with /request", req.path!!.endsWith("/request"))
+        val body = req.body.readUtf8()
+        assertTrue("body must contain node_id", body.contains("\"node_id\""))
+        assertTrue("body must contain query_id value", body.contains("\"qid-1\""))
+        assertTrue("body must contain query_string value", body.contains("\"water cycle\""))
+    }
+
+    @Test
+    fun submitRequest_doesNotStoreAnythingInDb() = runTest {
+        // POST /request is fire-and-forget; chunks arrive later via pollAndFetch.
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        syncManager.submitRequest("qid-1", "water cycle")
+        assertTrue(db.bundleDao().getByQueryId("qid-1").isEmpty())
+    }
+
+    @Test
+    fun submitRequest_noPayloadFileWritten() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        syncManager.submitRequest("qid-1", "water cycle")
+        assertTrue("no bundle file should be written on submit", testFilesDir.listFiles()!!.isEmpty())
+    }
+
+    // --- pollAndFetch ---
+
+    @Test
+    fun pollAndFetch_storesAllPendingBundles() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-a", "qid-b")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-a"))))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-b"))))
+        syncManager.pollAndFetch()
+        val pendingPath = server.takeRequest().path!!
+        assertTrue(
+            "GET /pending must include node_id query param",
+            pendingPath.contains("node_id=test-node-id"),
+        )
+        assertNotNull(db.bundleDao().getById("qid-a:0"))
+        assertNotNull(db.bundleDao().getById("qid-b:0"))
+    }
+
+    @Test
+    fun pollAndFetch_skipsFailingQueryId_continuesRest() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-fail", "qid-ok")))
+        server.enqueue(MockResponse().setResponseCode(404).setBody("Not Found"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-ok"))))
+        // Must not throw despite the 404 on the first ID
+        syncManager.pollAndFetch()
+        val pendingPath = server.takeRequest().path!!
+        assertTrue(
+            "GET /pending must include node_id query param",
+            pendingPath.contains("node_id=test-node-id"),
+        )
+        assertNull(db.bundleDao().getById("qid-fail:0"))
+        assertNotNull(db.bundleDao().getById("qid-ok:0"))
+    }
+
+    @Test
+    fun pollAndFetch_emptyPending_noDbWrites() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson()))
+        syncManager.pollAndFetch()
+        val pendingPath = server.takeRequest().path!!
+        assertTrue(
+            "GET /pending must include node_id query param",
+            pendingPath.contains("node_id=test-node-id"),
+        )
+        // No /bundle/ requests should have been made
+        assertEquals(1, server.requestCount) // only the /pending call
+        assertTrue(db.bundleDao().getByQueryId("any").isEmpty())
+    }
+}

--- a/android/app/src/androidTest/java/com/wake/dtn/service/WakeHttpClientTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/WakeHttpClientTest.kt
@@ -1,0 +1,164 @@
+package com.wake.dtn.service
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class WakeHttpClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: WakeHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = WakeHttpClient(baseUrl = server.url("/").toString().trimEnd('/'))
+    }
+
+    @After
+    fun tearDown() {
+        if (::server.isInitialized) runCatching { server.shutdown() }
+    }
+
+    // --- helpers ---
+
+    private fun chunkJson(
+        queryId: String = "qid-1",
+        chunkIndex: Int = 0,
+        totalChunks: Int = 1,
+        payloadB64: String = "aGVsbG8=",
+        sha256: String = "abc123",
+    ) = """{"server_id":"wake-server-01","query_id":"$queryId","chunk_index":$chunkIndex,""" +
+        """"total_chunks":$totalChunks,"content_type":"text/html","payload_b64":"$payloadB64",""" +
+        """"sha256":"$sha256","signature":null}"""
+
+    private fun chunksJson(vararg chunks: String) = "[${chunks.joinToString(",")}]"
+
+    // --- submitRequest ---
+
+    @Test
+    fun submitRequest_succeedsOn2xx() = runTest {
+        // POST /request is fire-and-forget; server returns an ack, not chunks.
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        client.submitRequest("node-1", "qid-1", "water cycle")
+        // No exception thrown — request was sent and server responded with 2xx.
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun submitRequest_requestBodyHasCorrectSnakeCaseFields() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        client.submitRequest("node-1", "qid-snake", "water cycle")
+        val body = server.takeRequest().body.readUtf8()
+        assertTrue("node_id missing", body.contains("\"node_id\""))
+        assertTrue("query_id missing", body.contains("\"query_id\""))
+        assertTrue("query_string missing", body.contains("\"query_string\""))
+        assertTrue("ttl_seconds missing", body.contains("\"ttl_seconds\""))
+        assertTrue("hop_count missing", body.contains("\"hop_count\""))
+    }
+
+    @Test
+    fun submitRequest_timestampIsUnixSeconds() = runTest {
+        val before = System.currentTimeMillis() / 1_000L
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        client.submitRequest("node-1", "qid-ts", "test")
+        val after = System.currentTimeMillis() / 1_000L
+        val body = server.takeRequest().body.readUtf8()
+        val ts = Regex("\"timestamp\":(\\d+)").find(body)!!.groupValues[1].toLong()
+        assertTrue("timestamp $ts not in [$before, $after]", ts in before..after)
+    }
+
+    @Test
+    fun submitRequest_onHttpError_throwsIOException() = runTest {
+        server.enqueue(MockResponse().setResponseCode(502).setBody("Bad Gateway"))
+        try {
+            client.submitRequest("node-1", "qid-err", "test")
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue("message should include status code", e.message!!.contains("502"))
+        }
+    }
+
+    // --- fetchPending ---
+
+    @Test
+    fun fetchPending_returnsQueryIds() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("""{"pending_query_ids":["id1","id2"]}""")
+        )
+        val result = client.fetchPending("my-node-id")
+        assertEquals(listOf("id1", "id2"), result)
+        val path = server.takeRequest().path!!
+        assertTrue("request must include node_id query param", path.contains("node_id=my-node-id"))
+    }
+
+    @Test
+    fun fetchPending_returnsEmptyList() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("""{"pending_query_ids":[]}""")
+        )
+        val result = client.fetchPending("my-node-id")
+        assertTrue(result.isEmpty())
+        val path = server.takeRequest().path!!
+        assertTrue("request must include node_id query param", path.contains("node_id=my-node-id"))
+    }
+
+    // --- fetchBundle ---
+
+    @Test
+    fun fetchBundle_returnsChunks() = runTest {
+        val body = chunksJson(
+            chunkJson(chunkIndex = 0, totalChunks = 2, payloadB64 = "aGVsbG8="),
+            chunkJson(chunkIndex = 1, totalChunks = 2, payloadB64 = "d29ybGQ="),
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(body))
+        val result = client.fetchBundle("qid-1")
+        assertEquals(2, result.size)
+        assertEquals(0, result[0].chunkIndex)
+        assertEquals(1, result[1].chunkIndex)
+        assertEquals("aGVsbG8=", result[0].payloadB64)
+        assertEquals("d29ybGQ=", result[1].payloadB64)
+    }
+
+    @Test
+    fun fetchBundle_on404_throwsIOException() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("Not Found"))
+        try {
+            client.fetchBundle("nonexistent")
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue("message should include status code", e.message!!.contains("404"))
+        }
+    }
+
+    @Test
+    fun fetchBundle_urlEncodesQueryIdInPath() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson())))
+        client.fetchBundle("my query id")
+        val path = server.takeRequest().path!!
+        // HttpUrl.Builder.addPathSegment encodes spaces as %20
+        assertTrue("path should encode spaces", path.contains("my%20query%20id"))
+    }
+
+    @Test
+    fun fetchBundle_pathContainsBundleSegment() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson())))
+        client.fetchBundle("qid-path-test")
+        val path = server.takeRequest().path!!
+        assertTrue("path should start with /bundle/", path.startsWith("/bundle/"))
+        assertTrue("path should end with query ID", path.endsWith("qid-path-test"))
+    }
+}

--- a/android/app/src/androidTest/java/com/wake/dtn/service/WakeServiceTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/WakeServiceTest.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ServiceTestRule
-import kotlinx.coroutines.isActive
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -41,6 +40,6 @@ class WakeServiceTest {
     @Test
     fun coroutineScope_isActiveAfterBind() {
         val service = bindToService()
-        assertTrue(service.scope.isActive)
+        assertTrue(service.isScopeActive)
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -12,6 +13,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Wake">

--- a/android/app/src/main/java/com/wake/dtn/service/ServerSyncManager.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/ServerSyncManager.kt
@@ -1,0 +1,81 @@
+package com.wake.dtn.service
+
+import android.util.Base64
+import android.util.Log
+import com.wake.dtn.data.BundleEntity
+import com.wake.dtn.data.BundleStoreManager
+import com.wake.dtn.data.BundleType
+
+/**
+ * Orchestrates WAKE server sync: submits request bundles, polls for pending results,
+ * fetches response chunks, and stores them via [BundleStoreManager].
+ */
+class ServerSyncManager(
+    private val httpClient: WakeHttpClient,
+    private val storeManager: BundleStoreManager,
+    val nodeId: String,
+) {
+    /**
+     * POST a request bundle to the server. Fire-and-forget: the server queues the request
+     * and response chunks are collected later via [pollAndFetch]. Throws [java.io.IOException]
+     * on non-2xx responses.
+     */
+    suspend fun submitRequest(queryId: String, queryString: String) {
+        httpClient.submitRequest(
+            nodeId = nodeId,
+            queryId = queryId,
+            queryString = queryString,
+        )
+    }
+
+    /**
+     * Poll [/pending] and fetch + store all outstanding response bundles.
+     * A failure for one query ID is logged and skipped; the rest of the loop continues.
+     */
+    suspend fun pollAndFetch() {
+        val pending = httpClient.fetchPending(nodeId)
+        if (pending.isEmpty()) return
+
+        Log.d(TAG, "pollAndFetch: found ${pending.size} pending IDs")
+        for (queryId in pending) {
+            runCatching {
+                storeChunks(httpClient.fetchBundle(queryId))
+            }.onFailure { e ->
+                Log.w(TAG, "Failed to fetch bundle for queryId=$queryId", e)
+            }
+        }
+    }
+
+    private suspend fun storeChunks(chunks: List<ResponseBundleDto>) {
+        val nowMs = System.currentTimeMillis()
+        for (chunk in chunks) {
+            val payloadBytes = Base64.decode(chunk.payloadB64, Base64.DEFAULT)
+            storeManager.store(chunk.toEntity(nowMs), payloadBytes)
+        }
+    }
+
+    companion object {
+        private const val TAG = "ServerSyncManager"
+    }
+}
+
+private fun ResponseBundleDto.toEntity(receivedAtMs: Long) = BundleEntity(
+    bundleId = "$queryId:$chunkIndex",
+    bundleType = BundleType.RESPONSE,
+    queryId = queryId,
+    sourceId = serverId,
+    timestampMs = receivedAtMs,
+    // Server does not expose TTL in the response body; default used until Phase 4 routing.
+    ttlSeconds = DEFAULT_RESPONSE_TTL_SECONDS,
+    hopCount = 0,
+    signature = signature,
+    queryString = null,
+    chunkIndex = chunkIndex,
+    totalChunks = totalChunks,
+    contentType = contentType,
+    payloadSha256 = sha256,
+    payloadFilePath = "${queryId}_${chunkIndex}.bundle",
+    receivedAtMs = receivedAtMs,
+)
+
+private const val DEFAULT_RESPONSE_TTL_SECONDS = 3_600

--- a/android/app/src/main/java/com/wake/dtn/service/WakeHttpClient.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/WakeHttpClient.kt
@@ -1,0 +1,123 @@
+package com.wake.dtn.service
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+@Serializable
+internal data class RequestBundleDto(
+    @SerialName("node_id") val nodeId: String,
+    @SerialName("query_id") val queryId: String,
+    @SerialName("query_string") val queryString: String,
+    val timestamp: Long,
+    @SerialName("ttl_seconds") val ttlSeconds: Int,
+    @SerialName("hop_count") val hopCount: Int,
+    val signature: String? = null,
+)
+
+@Serializable
+data class ResponseBundleDto(
+    @SerialName("server_id") val serverId: String,
+    @SerialName("query_id") val queryId: String,
+    @SerialName("chunk_index") val chunkIndex: Int,
+    @SerialName("total_chunks") val totalChunks: Int,
+    @SerialName("content_type") val contentType: String,
+    @SerialName("payload_b64") val payloadB64: String,
+    val sha256: String,
+    val signature: String? = null,
+)
+
+@Serializable
+private data class PendingResponseDto(
+    @SerialName("pending_query_ids") val pendingQueryIds: List<String>,
+)
+
+/**
+ * Thin OkHttp wrapper for the three WAKE server endpoints.
+ *
+ * Every call blocks on [Dispatchers.IO]. A non-2xx HTTP status throws [IOException]
+ * with the code and body included, so callers can log useful detail.
+ *
+ * [baseUrl] must not have a trailing slash (e.g. "http://10.0.2.2:8000").
+ */
+class WakeHttpClient(
+    baseUrl: String,
+    private val client: OkHttpClient = OkHttpClient(),
+) {
+    private val baseHttpUrl = baseUrl.trimEnd('/').toHttpUrl()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** POST a request bundle to the server. Throws [IOException] on non-2xx. */
+    suspend fun submitRequest(
+        nodeId: String,
+        queryId: String,
+        queryString: String,
+        ttlSeconds: Int = DEFAULT_TTL_SECONDS,
+    ) {
+        val dto = RequestBundleDto(
+            nodeId = nodeId,
+            queryId = queryId,
+            queryString = queryString,
+            // Server expects Unix seconds, not milliseconds.
+            timestamp = System.currentTimeMillis() / 1_000L,
+            ttlSeconds = ttlSeconds,
+            hopCount = 0,
+        )
+        val request = Request.Builder()
+            .url(baseHttpUrl.newBuilder().addPathSegment("request").build())
+            .post(json.encodeToString(dto).toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        executeAndGetBody(request)
+    }
+
+    /** GET /pending?node_id={nodeId} and return the list of query IDs the server has ready for this node. */
+    suspend fun fetchPending(nodeId: String): List<String> {
+        val request = Request.Builder()
+            .url(
+                baseHttpUrl.newBuilder()
+                    .addPathSegment("pending")
+                    .addQueryParameter("node_id", nodeId)
+                    .build()
+            )
+            .get()
+            .build()
+        return json.decodeFromString<PendingResponseDto>(executeAndGetBody(request)).pendingQueryIds
+    }
+
+    /** GET /bundle/{queryId} and return all stored response chunks for that query. */
+    suspend fun fetchBundle(queryId: String): List<ResponseBundleDto> {
+        val url = baseHttpUrl.newBuilder()
+            .addPathSegment("bundle")
+            .addPathSegment(queryId)
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+        return json.decodeFromString(executeAndGetBody(request))
+    }
+
+    private suspend fun executeAndGetBody(request: Request): String = withContext(Dispatchers.IO) {
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string() ?: ""
+            if (!response.isSuccessful) {
+                throw IOException("HTTP ${response.code}: $body")
+            }
+            body
+        }
+    }
+
+    companion object {
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+        private const val DEFAULT_TTL_SECONDS = 3_600
+    }
+}

--- a/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
@@ -16,12 +16,19 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.UUID
 
 class WakeService : Service() {
 
-    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** True while the service is alive and its background coroutines are running. */
+    val isScopeActive: Boolean get() = scope.isActive
 
     lateinit var bundleStoreManager: BundleStoreManager
+        private set
+
+    lateinit var syncManager: ServerSyncManager
         private set
 
     private val binder = LocalBinder()
@@ -40,14 +47,33 @@ class WakeService : Service() {
             dao = WakeDatabase.getInstance(this).bundleDao(),
         )
 
+        // Node identity is ephemeral for Phase 2; persistent Keystore identity is issue #31.
+        val nodeId = UUID.randomUUID().toString()
+        syncManager = ServerSyncManager(
+            httpClient = WakeHttpClient(baseUrl = SERVER_BASE_URL),
+            storeManager = bundleStoreManager,
+            nodeId = nodeId,
+        )
+
         scope.launch {
             while (isActive) {
-                delay(TTL_CHECK_INTERVAL_MS)
                 try {
                     bundleStoreManager.runTtlEviction()
                 } catch (e: Exception) {
                     Log.e(TAG, "TTL eviction failed; will retry next interval", e)
                 }
+                delay(TTL_CHECK_INTERVAL_MS)
+            }
+        }
+
+        scope.launch {
+            while (isActive) {
+                try {
+                    syncManager.pollAndFetch()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Sync poll failed; will retry next interval", e)
+                }
+                delay(SYNC_INTERVAL_MS)
             }
         }
     }
@@ -68,6 +94,10 @@ class WakeService : Service() {
         private const val TAG = "WakeService"
         const val NOTIFICATION_ID = 1
         const val TTL_CHECK_INTERVAL_MS = 5 * 60 * 1_000L
+        const val SYNC_INTERVAL_MS = 30 * 1_000L
+
+        /** Change to your laptop's LAN IP for on-device testing; issue #37 makes this configurable. */
+        const val SERVER_BASE_URL = "http://192.168.1.90:8000"
 
         fun start(context: Context) {
             ContextCompat.startForegroundService(

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    WAKE only ever communicates with a server on the local LAN (laptop, Pi hotspot, or
+    emulator loopback). It never contacts a public internet host, so permitting cleartext
+    globally is safe and is required because Android 9+ blocks HTTP by default.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,5 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ testOrchestrator = "1.5.1"
 room = "2.8.4"
 ksp = "2.3.6"
 coroutinesTest = "1.10.2"
+okhttp = "4.12.0"
+kotlinxSerializationJson = "1.8.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,8 +38,12 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Closes #32 
- Introduced coding rules for Kotlin and Android development in `android.md`.
- Defined stack, code style, architecture, and testing guidelines.

feat(server): establish Python and FastAPI conventions for WAKE server

- Created server rules in `server.md` detailing stack, code style, error handling, and testing practices.

chore: add Claude settings for permissions

- Configured `.claude/settings.json` to allow specific Bash commands for testing and building.

chore: update .gitignore for local Claude settings

- Added entries to ignore local Claude settings and project directories.

docs: create CLAUDE.md for project guidance

- Documented project identity, architecture, branching strategy, server and Android setup, constraints, and learned corrections.

feat(android): enhance build configuration with serialization support

- Updated `build.gradle.kts` to include Kotlin serialization plugin and dependencies.

fix(android): improve database closure handling in tests

- Modified `closeDb` methods in test classes to safely close the database if initialized.

feat(android): add ServerSyncManager and WakeHttpClient for server communication

- Implemented `ServerSyncManager` for orchestrating server sync operations.
- Created `WakeHttpClient` for handling HTTP requests to the WAKE server.

feat(android): implement server synchronization in WakeService

- Integrated `ServerSyncManager` into `WakeService` for periodic polling and fetching.

chore(android): add network security configuration for cleartext traffic

- Created `network_security_config.xml` to permit cleartext traffic for local server communication.

fix(android): ensure proper permissions in AndroidManifest.xml

- Added INTERNET permission to `AndroidManifest.xml` for network access.