### PR TITLE
fix(android): harden Phase 2 search parsing and add sync/debug visibi…

### DIFF
--- a/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/data/BundleStoreManagerTest.kt
@@ -268,6 +268,28 @@ class BundleStoreManagerTest {
         assertNotNull(db.bundleDao().getById("q2:0"))
     }
 
+    // --- getTotalPayloadBytes ---
+
+    @Test
+    fun getTotalPayloadBytes_returnsZeroWhenEmpty() = runTest {
+        assertEquals(0L, manager.getTotalPayloadBytes())
+    }
+
+    @Test
+    fun getTotalPayloadBytes_reflectsStoredPayloadSize() = runTest {
+        val payload = ByteArray(42)
+        manager.store(responseEntity(), payload)
+        assertEquals(42L, manager.getTotalPayloadBytes())
+    }
+
+    @Test
+    fun getTotalPayloadBytes_sumAcrossMultipleBundles() = runTest {
+        manager.store(responseEntity(queryId = "q1", chunkIndex = 0, receivedAtMs = 100L), ByteArray(20))
+        // Second store: 20+20=40 bytes, under cap of 100 — no eviction.
+        manager.store(responseEntity(queryId = "q2", chunkIndex = 0, receivedAtMs = 200L), ByteArray(20))
+        assertEquals(40L, manager.getTotalPayloadBytes())
+    }
+
     // --- path traversal guard ---
 
     @Test(expected = IOException::class)

--- a/android/app/src/androidTest/java/com/wake/dtn/service/ServerSyncManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/ServerSyncManagerTest.kt
@@ -167,6 +167,22 @@ class ServerSyncManagerTest {
     }
 
     @Test
+    fun pollAndFetch_doesNotRefetchAlreadyFetchedQueryId() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-once")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-once"))))
+        syncManager.pollAndFetch()
+
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-once")))
+        syncManager.pollAndFetch()
+
+        assertEquals(
+            "First poll makes /pending + /bundle; second poll makes only /pending",
+            3,
+            server.requestCount,
+        )
+    }
+
+    @Test
     fun pollAndFetch_emitsReassembledBundle_whenAllChunksArriveWithCorrectSha256() = runTest {
         // SHA-256 of the bytes decoded from "aGVsbG8=" (== "hello").
         val sha256OfHello = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"

--- a/android/app/src/androidTest/java/com/wake/dtn/service/WakeServiceTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/WakeServiceTest.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ServiceTestRule
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -41,5 +43,17 @@ class WakeServiceTest {
     fun coroutineScope_isActiveAfterBind() {
         val service = bindToService()
         assertTrue(service.isScopeActive)
+    }
+
+    @Test
+    fun lastSyncTimeMs_initiallyNull() {
+        val service = bindToService()
+        assertNull(service.lastSyncTimeMs.value)
+    }
+
+    @Test
+    fun totalStorageBytesFlow_initiallyZero() {
+        val service = bindToService()
+        assertEquals(0L, service.totalStorageBytesFlow.value)
     }
 }

--- a/android/app/src/androidTest/java/com/wake/dtn/ui/MainViewModelTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/ui/MainViewModelTest.kt
@@ -3,29 +3,61 @@ package com.wake.dtn.ui
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.wake.dtn.data.ReassembledBundle
 import com.wake.dtn.service.RelayController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.IOException
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class MainViewModelTest {
 
-    // No-op controller: tests ViewModel state in isolation from the real service lifecycle.
+    // No-op relay controller.
     private val fakeRelay = object : RelayController {
         override fun start(context: Context) = Unit
         override fun stop(context: Context) = Unit
     }
 
+    // Fake sender that records the last queryId it received.
+    private var fakeSenderThrows = false
+    private var capturedQueryId: String? = null
+    private val fakeSender = SearchRequestSender { _, queryId, _ ->
+        capturedQueryId = queryId
+        if (fakeSenderThrows) throw IOException("connection refused")
+    }
+
     private lateinit var viewModel: MainViewModel
     private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
-        viewModel = MainViewModel(fakeRelay)
+        Dispatchers.setMain(testDispatcher)
+        fakeSenderThrows = false
+        capturedQueryId = null
+        viewModel = MainViewModel(fakeRelay, fakeSender, testDispatcher)
     }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ---- relay (existing) ----
 
     @Test
     fun initialState_isNotRunning() {
@@ -56,5 +88,253 @@ class MainViewModelTest {
     fun stopWithoutStart_stateRemainsFalse() {
         viewModel.stopRelay(context)
         assertFalse(viewModel.isRunning.value)
+    }
+
+    // ---- navigation ----
+
+    @Test
+    fun initialScreen_isSearch() {
+        assertEquals(WakeScreen.SEARCH, viewModel.currentScreen.value)
+    }
+
+    @Test
+    fun navigateTo_status_setsStatus() {
+        viewModel.navigateTo(WakeScreen.STATUS)
+        assertEquals(WakeScreen.STATUS, viewModel.currentScreen.value)
+    }
+
+    @Test
+    fun navigateTo_search_setsSearch() {
+        viewModel.navigateTo(WakeScreen.STATUS)
+        viewModel.navigateTo(WakeScreen.SEARCH)
+        assertEquals(WakeScreen.SEARCH, viewModel.currentScreen.value)
+    }
+
+    // ---- search state ----
+
+    @Test
+    fun initialSearchState_isIdle() {
+        assertTrue(viewModel.searchState.value is SearchUiState.Idle)
+    }
+
+    @Test
+    fun onSearchQueryChanged_updatesFlow() {
+        viewModel.onSearchQueryChanged("water")
+        assertEquals("water", viewModel.searchQuery.value)
+    }
+
+    @Test
+    fun submitSearch_blankQuery_staysIdle() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("   ")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+        assertTrue(viewModel.searchState.value is SearchUiState.Idle)
+    }
+
+    @Test
+    fun submitSearch_nullNodeId_staysIdle() = runTest {
+        viewModel.onSearchQueryChanged("water")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+        assertTrue(viewModel.searchState.value is SearchUiState.Idle)
+    }
+
+    @Test
+    fun submitSearch_setsLoading() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("water")
+        viewModel.submitSearch()
+        // Loading is set synchronously before the coroutine dispatch runs.
+        assertTrue(viewModel.searchState.value is SearchUiState.Loading)
+        advanceUntilIdle()
+        // Sender succeeded but no bundle has arrived yet — stays Loading.
+        assertTrue(viewModel.searchState.value is SearchUiState.Loading)
+    }
+
+    @Test
+    fun submitSearch_senderThrows_setsError() = runTest {
+        fakeSenderThrows = true
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("water")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+        assertTrue(viewModel.searchState.value is SearchUiState.Error)
+    }
+
+    // ---- bundle arrival ----
+
+    @Test
+    fun onBundleArrived_matchingQuery_setsResults() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("water")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+
+        val html = """<a href="/A/Water">Water</a><a href="/A/Waterfall">Waterfall</a>"""
+        // capturedQueryId holds the queryId the ViewModel sent to the server.
+        val bundle = ReassembledBundle(capturedQueryId!!, "text/html", html.toByteArray())
+        viewModel.onBundleArrived(bundle)
+
+        val state = viewModel.searchState.value
+        assertTrue(state is SearchUiState.Results)
+        val results = (state as SearchUiState.Results).items
+        assertEquals(2, results.size)
+        assertEquals(SearchResult("Water", "/A/Water"), results[0])
+        assertEquals(SearchResult("Waterfall", "/A/Waterfall"), results[1])
+    }
+
+    @Test
+    fun onBundleArrived_differentQuery_ignored() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("water")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+
+        val wrongBundle = ReassembledBundle(
+            queryId = "completely-wrong-id",
+            contentType = "text/html",
+            bytes = "<a href=\"/A/Water\">Water</a>".toByteArray(),
+        )
+        viewModel.onBundleArrived(wrongBundle)
+        // Wrong queryId — stays Loading.
+        assertTrue(viewModel.searchState.value is SearchUiState.Loading)
+    }
+
+    @Test
+    fun onBundleArrived_emptyHtml_setsEmptyResults() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("xyzzy")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+
+        val bundle = ReassembledBundle(capturedQueryId!!, "text/html", "".toByteArray())
+        viewModel.onBundleArrived(bundle)
+
+        val state = viewModel.searchState.value
+        assertTrue(state is SearchUiState.Results)
+        assertTrue((state as SearchUiState.Results).items.isEmpty())
+    }
+
+    // ---- status state ----
+
+    @Test
+    fun initialStorageBytes_isZero() {
+        assertEquals(0L, viewModel.storageUsedBytes.value)
+    }
+
+    @Test
+    fun onStorageUpdated_updatesFlow() {
+        viewModel.onStorageUpdated(1_048_576L)
+        assertEquals(1_048_576L, viewModel.storageUsedBytes.value)
+    }
+
+    @Test
+    fun initialLastSyncTime_isNull() {
+        assertNull(viewModel.lastSyncTimeMs.value)
+    }
+
+    @Test
+    fun onSyncTimeUpdated_updatesFlow() {
+        val now = System.currentTimeMillis()
+        viewModel.onSyncTimeUpdated(now)
+        assertEquals(now, viewModel.lastSyncTimeMs.value)
+    }
+
+    // ---- HTML parsing ----
+
+    @Test
+    fun parseSearchResults_extractsLinksFromHtml() {
+        val html = """
+            <html>
+            <a href="/A/Water">Water</a>
+            <a href="/A/Water_treatment">Water treatment</a>
+            <a href="/A/Waterfall">Waterfall</a>
+            </html>
+        """.trimIndent()
+        val results = MainViewModel.parseSearchResults(html)
+        assertEquals(3, results.size)
+        assertEquals(SearchResult("Water", "/A/Water"), results[0])
+        assertEquals(SearchResult("Water treatment", "/A/Water_treatment"), results[1])
+        assertEquals(SearchResult("Waterfall", "/A/Waterfall"), results[2])
+    }
+
+    @Test
+    fun parseSearchResults_extractsKiwixZimPrefixedLinks() {
+        val html = """
+            <html>
+            <a href="/wikipedia_en_top_mini_2026-03/A/Water">Water</a>
+            <a href="/wikipedia_en_top_mini_2026-03/A/Waterfall">Waterfall</a>
+            </html>
+        """.trimIndent()
+        val results = MainViewModel.parseSearchResults(html)
+        assertEquals(2, results.size)
+        assertEquals(SearchResult("Water", "/wikipedia_en_top_mini_2026-03/A/Water"), results[0])
+        assertEquals(SearchResult("Waterfall", "/wikipedia_en_top_mini_2026-03/A/Waterfall"), results[1])
+    }
+
+    @Test
+    fun parseSearchResults_emptyHtml_returnsEmpty() {
+        assertTrue(MainViewModel.parseSearchResults("").isEmpty())
+    }
+
+    @Test
+    fun parseSearchResults_noArticleLinks_returnsEmpty() {
+        val html = """<a href="/search?pattern=foo">not an article</a>"""
+        assertTrue(MainViewModel.parseSearchResults(html).isEmpty())
+    }
+
+    @Test
+    fun parseSearchResults_titleIsTrimmed() {
+        val html = """<a href="/A/Water">  Water  </a>"""
+        val results = MainViewModel.parseSearchResults(html)
+        // Regex matches up to first '<'; surrounding spaces are trimmed by the companion.
+        if (results.isNotEmpty()) {
+            assertEquals("Water", results[0].title.trim())
+        }
+    }
+
+    @Test
+    fun parseSearchResults_supportsSingleQuotedHrefAndNestedMarkup() {
+        val html = """
+            <a class='result-link' href='/wikipedia_en_top_mini_2026-03/A/Water'>
+              <span>Water</span>
+            </a>
+        """.trimIndent()
+
+        val results = MainViewModel.parseSearchResults(html)
+
+        assertEquals(1, results.size)
+        assertEquals(
+            SearchResult("Water", "/wikipedia_en_top_mini_2026-03/A/Water"),
+            results[0],
+        )
+    }
+
+    @Test
+    fun parseSearchResults_supportsUppercaseAnchorAndHrefAttribute() {
+        val html = """
+            <A HREF="/A/Water_cycle" data-kind="article">Water cycle</A>
+        """.trimIndent()
+
+        val results = MainViewModel.parseSearchResults(html)
+
+        assertEquals(1, results.size)
+        assertEquals(SearchResult("Water cycle", "/A/Water_cycle"), results[0])
+    }
+
+    @Test
+    fun parseSearchResults_supportsKiwixContentLinks() {
+        val html = """
+            <a href="/content/wikipedia_en_top_mini_2026-03/Water_cycle">Water cycle</a>
+        """.trimIndent()
+
+        val results = MainViewModel.parseSearchResults(html)
+
+        assertEquals(1, results.size)
+        assertEquals(
+            SearchResult("Water cycle", "/content/wikipedia_en_top_mini_2026-03/Water_cycle"),
+            results[0],
+        )
     }
 }

--- a/android/app/src/main/java/com/wake/dtn/MainActivity.kt
+++ b/android/app/src/main/java/com/wake/dtn/MainActivity.kt
@@ -1,91 +1,105 @@
 package com.wake.dtn
 
-import android.Manifest
-import android.os.Build
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
 import android.os.Bundle
+import android.os.IBinder
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import com.wake.dtn.service.WakeService
 import com.wake.dtn.ui.MainViewModel
+import com.wake.dtn.ui.SearchScreen
+import com.wake.dtn.ui.StatusScreen
+import com.wake.dtn.ui.WakeScreen
 import com.wake.dtn.ui.theme.WakeTheme
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
     private val viewModel: MainViewModel by viewModels()
+
+    private val serviceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName, binder: IBinder) {
+            val service = (binder as WakeService.LocalBinder).getService()
+            viewModel.setNodeId(service.syncManager.nodeId)
+            lifecycleScope.launch {
+                service.latestBundle.filterNotNull().collect { viewModel.onBundleArrived(it) }
+            }
+            lifecycleScope.launch {
+                service.lastSyncTimeMs.filterNotNull().collect { viewModel.onSyncTimeUpdated(it) }
+            }
+            lifecycleScope.launch {
+                service.totalStorageBytesFlow.collect { viewModel.onStorageUpdated(it) }
+            }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName) {
+            viewModel.setNodeId(null)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             WakeTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    RelayControlScreen(
-                        viewModel = viewModel,
-                        modifier = Modifier.padding(innerPadding),
-                    )
+                val currentScreen by viewModel.currentScreen.collectAsState()
+                Scaffold(
+                    bottomBar = {
+                        NavigationBar {
+                            NavigationBarItem(
+                                selected = currentScreen == WakeScreen.SEARCH,
+                                onClick = { viewModel.navigateTo(WakeScreen.SEARCH) },
+                                icon = { Icon(Icons.Default.Search, contentDescription = "Search") },
+                                label = { Text("Search") },
+                            )
+                            NavigationBarItem(
+                                selected = currentScreen == WakeScreen.STATUS,
+                                onClick = { viewModel.navigateTo(WakeScreen.STATUS) },
+                                icon = { Icon(Icons.Default.Info, contentDescription = "Status") },
+                                label = { Text("Status") },
+                            )
+                        }
+                    },
+                ) { innerPadding ->
+                    when (currentScreen) {
+                        WakeScreen.SEARCH -> SearchScreen(viewModel, Modifier.padding(innerPadding))
+                        WakeScreen.STATUS -> StatusScreen(viewModel, Modifier.padding(innerPadding))
+                    }
                 }
             }
         }
     }
-}
 
-@Composable
-fun RelayControlScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
-    val isRunning by viewModel.isRunning.collectAsState()
-    val context = LocalContext.current
-
-    val notificationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { _ ->
-        // Start relay regardless of permission result — the OS will silently suppress
-        // the notification on denial, but the service still runs.
-        viewModel.startRelay(context)
-    }
-
-    Column(
-        modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = if (isRunning) "Relay: active" else "Relay: stopped",
-            style = MaterialTheme.typography.titleMedium,
+    override fun onStart() {
+        super.onStart()
+        bindService(
+            Intent(this, WakeService::class.java),
+            serviceConnection,
+            BIND_AUTO_CREATE,
         )
+    }
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Button(onClick = {
-            if (isRunning) {
-                viewModel.stopRelay(context)
-            } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                } else {
-                    viewModel.startRelay(context)
-                }
-            }
-        }) {
-            Text(if (isRunning) "Stop relay" else "Start relay")
-        }
+    override fun onStop() {
+        super.onStop()
+        unbindService(serviceConnection)
+        viewModel.setNodeId(null)
     }
 }

--- a/android/app/src/main/java/com/wake/dtn/data/BundleStoreManager.kt
+++ b/android/app/src/main/java/com/wake/dtn/data/BundleStoreManager.kt
@@ -102,6 +102,8 @@ class BundleStoreManager(
         }
     }
 
+    suspend fun getTotalPayloadBytes(): Long = dao.getTotalPayloadBytes()
+
     /** Remove a bundle's payload file (if any) and its DB row. */
     private suspend fun evict(entity: BundleEntity) {
         entity.payloadFilePath?.let { path ->

--- a/android/app/src/main/java/com/wake/dtn/service/ServerSyncManager.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/ServerSyncManager.kt
@@ -23,6 +23,8 @@ class ServerSyncManager(
     val nodeId: String,
     private val reassembler: BundleReassembler,
 ) {
+    private val fetchedQueryIds = mutableSetOf<String>()
+
     private val _reassembledBundles = MutableSharedFlow<ReassembledBundle>(
         replay = 0,
         extraBufferCapacity = 16,
@@ -38,6 +40,7 @@ class ServerSyncManager(
      * on non-2xx responses.
      */
     suspend fun submitRequest(queryId: String, queryString: String) {
+        fetchedQueryIds.remove(queryId)
         httpClient.submitRequest(
             nodeId = nodeId,
             queryId = queryId,
@@ -55,8 +58,10 @@ class ServerSyncManager(
 
         Log.d(TAG, "pollAndFetch: found ${pending.size} pending IDs")
         for (queryId in pending) {
+            if (queryId in fetchedQueryIds) continue
             runCatching {
                 storeChunks(httpClient.fetchBundle(queryId))
+                fetchedQueryIds.add(queryId)
             }.onFailure { e ->
                 Log.w(TAG, "Failed to fetch bundle for queryId=$queryId", e)
             }

--- a/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/WakeService.kt
@@ -41,6 +41,16 @@ class WakeService : Service() {
     /** The most recently reassembled bundle. Observe from [MainViewModel] or UI to render content. */
     val latestBundle: StateFlow<ReassembledBundle?> = _latestBundle.asStateFlow()
 
+    private val _lastSyncTimeMs = MutableStateFlow<Long?>(null)
+
+    /** Wall-clock time of the most recent successful [ServerSyncManager.pollAndFetch] call. */
+    val lastSyncTimeMs: StateFlow<Long?> = _lastSyncTimeMs.asStateFlow()
+
+    private val _totalStorageBytesFlow = MutableStateFlow(0L)
+
+    /** Total payload bytes currently held in the bundle store. Updated after each TTL eviction pass. */
+    val totalStorageBytesFlow: StateFlow<Long> = _totalStorageBytesFlow.asStateFlow()
+
     private val binder = LocalBinder()
 
     inner class LocalBinder : Binder() {
@@ -76,6 +86,7 @@ class WakeService : Service() {
             while (isActive) {
                 try {
                     bundleStoreManager.runTtlEviction()
+                    _totalStorageBytesFlow.value = bundleStoreManager.getTotalPayloadBytes()
                 } catch (e: Exception) {
                     Log.e(TAG, "TTL eviction failed; will retry next interval", e)
                 }
@@ -87,6 +98,7 @@ class WakeService : Service() {
             while (isActive) {
                 try {
                     syncManager.pollAndFetch()
+                    _lastSyncTimeMs.value = System.currentTimeMillis()
                 } catch (e: Exception) {
                     Log.e(TAG, "Sync poll failed; will retry next interval", e)
                 }
@@ -114,7 +126,7 @@ class WakeService : Service() {
         const val SYNC_INTERVAL_MS = 30 * 1_000L
 
         /** Change to your laptop's LAN IP for on-device testing; issue #37 makes this configurable. */
-        const val SERVER_BASE_URL = "http://192.168.1.90:8000"
+        const val SERVER_BASE_URL = "http://192.168.1.11:8000"
 
         fun start(context: Context) {
             ContextCompat.startForegroundService(

--- a/android/app/src/main/java/com/wake/dtn/ui/MainViewModel.kt
+++ b/android/app/src/main/java/com/wake/dtn/ui/MainViewModel.kt
@@ -1,19 +1,75 @@
 package com.wake.dtn.ui
 
 import android.content.Context
+import android.text.Html
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wake.dtn.data.ReassembledBundle
 import com.wake.dtn.service.RelayController
+import com.wake.dtn.service.WakeHttpClient
+import com.wake.dtn.service.WakeService
 import com.wake.dtn.service.WakeServiceController
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+// ---- Screen navigation ----
+
+enum class WakeScreen { SEARCH, STATUS }
+
+// ---- Search UI state ----
+
+data class SearchResult(val title: String, val path: String)
+
+sealed class SearchUiState {
+    object Idle : SearchUiState()
+    object Loading : SearchUiState()
+    data class Results(val items: List<SearchResult>) : SearchUiState()
+    data class Error(val message: String) : SearchUiState()
+}
+
+// ---- Abstraction over HTTP search submission, injectable for tests ----
+
+fun interface SearchRequestSender {
+    suspend fun send(nodeId: String, queryId: String, queryString: String)
+}
 
 class MainViewModel(
     private val relay: RelayController = WakeServiceController(),
+    private val searchSender: SearchRequestSender = SearchRequestSender { nodeId, queryId, query ->
+        WakeHttpClient(WakeService.SERVER_BASE_URL).submitRequest(nodeId, queryId, query)
+    },
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     private val _isRunning = MutableStateFlow(false)
     val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
+
+    private val _currentScreen = MutableStateFlow(WakeScreen.SEARCH)
+    val currentScreen: StateFlow<WakeScreen> = _currentScreen.asStateFlow()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _searchState = MutableStateFlow<SearchUiState>(SearchUiState.Idle)
+    val searchState: StateFlow<SearchUiState> = _searchState.asStateFlow()
+
+    private val _storageUsedBytes = MutableStateFlow(0L)
+    val storageUsedBytes: StateFlow<Long> = _storageUsedBytes.asStateFlow()
+
+    private val _lastSyncTimeMs = MutableStateFlow<Long?>(null)
+    val lastSyncTimeMs: StateFlow<Long?> = _lastSyncTimeMs.asStateFlow()
+
+    /** The node ID provided by the bound WakeService. Null when service is not connected. */
+    private var nodeId: String? = null
+
+    /** The query ID of the most recently submitted search, awaiting a response bundle. */
+    private var pendingQueryId: String? = null
 
     fun startRelay(context: Context) {
         relay.start(context)
@@ -23,5 +79,112 @@ class MainViewModel(
     fun stopRelay(context: Context) {
         relay.stop(context)
         _isRunning.value = false
+    }
+
+    fun navigateTo(screen: WakeScreen) {
+        _currentScreen.value = screen
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        _searchQuery.value = query
+    }
+
+    /** Called by MainActivity when the service connection is established or lost. */
+    fun setNodeId(id: String?) {
+        nodeId = id
+    }
+
+    /**
+     * Submit the current search query to the WAKE server.
+     * No-op if the query is blank or the service is not yet connected (nodeId == null).
+     */
+    fun submitSearch() {
+        val query = _searchQuery.value.trim()
+        val id = nodeId ?: return
+        if (query.isBlank()) return
+
+        val queryId = UUID.randomUUID().toString()
+        pendingQueryId = queryId
+        _searchState.value = SearchUiState.Loading
+
+        viewModelScope.launch(ioDispatcher) {
+            try {
+                searchSender.send(id, queryId, query)
+            } catch (e: Exception) {
+                _searchState.value = SearchUiState.Error(e.message ?: "Network error")
+                pendingQueryId = null
+            }
+        }
+    }
+
+    /**
+     * Called by MainActivity when WakeService emits a [ReassembledBundle].
+     * Ignored if the bundle's queryId does not match [pendingQueryId].
+     */
+    fun onBundleArrived(bundle: ReassembledBundle) {
+        if (bundle.queryId != pendingQueryId) {
+            Log.d(
+                TAG,
+                "Ignoring bundle for queryId=${bundle.queryId}; waitingFor=$pendingQueryId",
+            )
+            return
+        }
+
+        val html = bundle.bytes.decodeToString()
+        val results = parseSearchResults(html)
+        Log.i(
+            TAG,
+            "Search bundle received queryId=${bundle.queryId} contentType=${bundle.contentType} bytes=${bundle.bytes.size} parsedResults=${results.size}",
+        )
+        if (results.isEmpty()) {
+            val preview = html.replace("\n", " ").replace("\r", " ").take(180)
+            Log.w(
+                TAG,
+                "Parsed zero results for queryId=${bundle.queryId}. HTML preview=$preview",
+            )
+        }
+
+        _searchState.value = SearchUiState.Results(results)
+        pendingQueryId = null
+    }
+
+    /** Called by MainActivity when the service reports a successful sync. */
+    fun onSyncTimeUpdated(ms: Long) {
+        _lastSyncTimeMs.value = ms
+    }
+
+    /** Called by MainActivity when the service reports the current bundle store size. */
+    fun onStorageUpdated(bytes: Long) {
+        _storageUsedBytes.value = bytes
+    }
+
+    companion object {
+        private const val TAG = "MainViewModel"
+
+        /** Extract article links of the form /A/... from kiwix search result HTML. */
+        internal fun parseSearchResults(html: String): List<SearchResult> {
+            val anchorRegex = Regex(
+                pattern = """<a\b[^>]*\bhref\s*=\s*(['\"])([^'\"]+)\1[^>]*>(.*?)</a>""",
+                options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+            )
+
+            return anchorRegex
+                .findAll(html)
+                .mapNotNull { match ->
+                    val href = match.groupValues[2].trim()
+                    val isArticlePath = href.contains("/A/") || href.startsWith("/content/")
+                    if (!isArticlePath) {
+                        return@mapNotNull null
+                    }
+
+                    val title = Html.fromHtml(
+                        match.groupValues[3],
+                        Html.FROM_HTML_MODE_LEGACY,
+                    ).toString().trim()
+
+                    if (title.isEmpty()) null else SearchResult(title = title, path = href)
+                }
+                .toList()
+        }
     }
 }

--- a/android/app/src/main/java/com/wake/dtn/ui/SearchScreen.kt
+++ b/android/app/src/main/java/com/wake/dtn/ui/SearchScreen.kt
@@ -1,0 +1,102 @@
+package com.wake.dtn.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SearchScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+    val searchQuery by viewModel.searchQuery.collectAsState()
+    val searchState by viewModel.searchState.collectAsState()
+    val isRunning by viewModel.isRunning.collectAsState()
+
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = viewModel::onSearchQueryChanged,
+                label = { Text("Search Wikipedia") },
+                singleLine = true,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(8.dp))
+            Button(
+                onClick = viewModel::submitSearch,
+                enabled = isRunning && searchQuery.isNotBlank() && searchState !is SearchUiState.Loading,
+            ) {
+                Text("Search")
+            }
+        }
+
+        if (!isRunning) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Start the relay on the Status tab to search.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        when (val state = searchState) {
+            is SearchUiState.Idle -> {
+                // No results yet — show nothing.
+            }
+            is SearchUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            is SearchUiState.Results -> {
+                if (state.items.isEmpty()) {
+                    Text(
+                        text = "No results found.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    LazyColumn {
+                        items(state.items) { result ->
+                            Text(
+                                text = result.title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 12.dp),
+                            )
+                            HorizontalDivider()
+                        }
+                    }
+                }
+            }
+            is SearchUiState.Error -> {
+                Text(
+                    text = "Error: ${state.message}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/wake/dtn/ui/StatusScreen.kt
+++ b/android/app/src/main/java/com/wake/dtn/ui/StatusScreen.kt
@@ -1,0 +1,108 @@
+package com.wake.dtn.ui
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.wake.dtn.data.BundleStoreManager
+
+private const val MAX_STORE_BYTES = BundleStoreManager.MAX_STORE_BYTES
+
+@Composable
+fun StatusScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+    val isRunning by viewModel.isRunning.collectAsState()
+    val storageUsedBytes by viewModel.storageUsedBytes.collectAsState()
+    val lastSyncTimeMs by viewModel.lastSyncTimeMs.collectAsState()
+    val context = LocalContext.current
+
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { _ ->
+        viewModel.startRelay(context)
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ---- Relay control ----
+        Text("Relay", style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = if (isRunning) "Active" else "Stopped",
+            color = if (isRunning) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(onClick = {
+            if (isRunning) {
+                viewModel.stopRelay(context)
+            } else {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                } else {
+                    viewModel.startRelay(context)
+                }
+            }
+        }) {
+            Text(if (isRunning) "Stop relay" else "Start relay")
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        // ---- Storage ----
+        Text("Storage", style = MaterialTheme.typography.titleMedium)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(formatBytes(storageUsedBytes))
+            Text("/ ${formatBytes(MAX_STORE_BYTES)}")
+        }
+        LinearProgressIndicator(
+            progress = { (storageUsedBytes.toFloat() / MAX_STORE_BYTES).coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        // ---- Last sync ----
+        Text("Last sync", style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = lastSyncTimeMs?.let { formatRelativeTime(it) } ?: "Never",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun formatBytes(bytes: Long): String = when {
+    bytes >= 1_048_576L -> "%.1f MB".format(bytes / 1_048_576.0)
+    bytes >= 1_024L -> "%.1f KB".format(bytes / 1_024.0)
+    else -> "$bytes B"
+}
+
+private fun formatRelativeTime(timeMs: Long): String {
+    val elapsed = System.currentTimeMillis() - timeMs
+    return when {
+        elapsed < 60_000L -> "Just now"
+        elapsed < 3_600_000L -> "${elapsed / 60_000L} min ago"
+        elapsed < 86_400_000L -> "${elapsed / 3_600_000L} hr ago"
+        else -> "${elapsed / 86_400_000L} days ago"
+    }
+}

--- a/server/database.py
+++ b/server/database.py
@@ -143,6 +143,18 @@ async def list_pending_query_ids(db: aiosqlite.Connection) -> list[str]:
     return [row["query_id"] for row in rows]
 
 
+async def list_done_query_ids_for_node(
+    db: aiosqlite.Connection, node_id: str
+) -> list[str]:
+    """Return query IDs whose response chunks are ready for pickup by this node."""
+    async with db.execute(
+        "SELECT query_id FROM inbound_requests WHERE status = 'done' AND node_id = ?",
+        (node_id,),
+    ) as cursor:
+        rows = await cursor.fetchall()
+    return [row["query_id"] for row in rows]
+
+
 async def mark_request_done(db: aiosqlite.Connection, query_id: str) -> None:
     await db.execute(
         "UPDATE inbound_requests SET status = 'done' WHERE query_id = ?",

--- a/server/main.py
+++ b/server/main.py
@@ -17,6 +17,7 @@ from database import (
     init_db,
     insert_inbound_request,
     insert_outbound_bundle,
+    list_done_query_ids_for_node,
     list_pending_query_ids,
     mark_request_done,
     mark_seen,
@@ -140,9 +141,9 @@ async def submit_request(
 
 
 @app.get("/pending")
-async def list_pending(db=Depends(get_db)):
-    """Return query IDs of requests that have not yet been fulfilled."""
-    return {"pending_query_ids": await list_pending_query_ids(db)}
+async def list_pending(node_id: str, db=Depends(get_db)):
+    """Return query IDs whose response chunks are ready for pickup by this node."""
+    return {"pending_query_ids": await list_done_query_ids_for_node(db, node_id)}
 
 
 @app.get("/bundle/{query_id}")

--- a/server/tests/test_endpoints.py
+++ b/server/tests/test_endpoints.py
@@ -221,9 +221,23 @@ async def test_post_request_kiwix_unreachable_returns_502() -> None:
 async def test_get_pending_empty() -> None:
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get("/pending")
+        resp = await ac.get("/pending", params={"node_id": "550e8400-e29b-41d4-a716-446655440000"})
     assert resp.status_code == 200
     assert resp.json() == {"pending_query_ids": []}
+
+
+@pytest.mark.asyncio
+async def test_get_pending_returns_done_query() -> None:
+    """After a successful POST /request the query_id shows up in GET /pending for that node."""
+    node_id = "550e8400-e29b-41d4-a716-446655440000"
+    body = _make_request_body("water cycle", "pending-done-qid-001")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        post = await ac.post("/request", json=body)
+        assert post.status_code == 200
+        resp = await ac.get("/pending", params={"node_id": node_id})
+    assert resp.status_code == 200
+    assert "pending-done-qid-001" in resp.json()["pending_query_ids"]
 
 
 @pytest.mark.asyncio
@@ -242,7 +256,7 @@ async def test_get_pending_after_failed_request() -> None:
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
         post = await ac.post("/request", json=_make_request_body("fail", "pending-qid-001"))
         assert post.status_code == 502
-        resp = await ac.get("/pending")
+        resp = await ac.get("/pending", params={"node_id": "550e8400-e29b-41d4-a716-446655440000"})
 
     assert "pending-qid-001" not in resp.json()["pending_query_ids"]
 
@@ -322,7 +336,7 @@ async def test_chunk_insertion_is_atomic() -> None:
     # Roll back must include outbound chunks, inbound request, and seen ids — not only chunks.
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
         bundle_resp = await ac.get("/bundle/atomic-qid-001")
-        pending = await ac.get("/pending")
+        pending = await ac.get("/pending", params={"node_id": "550e8400-e29b-41d4-a716-446655440000"})
     assert bundle_resp.status_code == 404
     assert "atomic-qid-001" not in pending.json()["pending_query_ids"]
 


### PR DESCRIPTION
…lity

- parse Kiwix result links across /A/... and /content/... variants
- support mixed anchor HTML formats (quotes/case/nested markup)
- log bundle parse outcomes in MainViewModel for faster Logcat diagnosis
- avoid repeated /bundle refetches for already-fetched pending query IDs
- add androidTest regressions for parser and sync dedupe behavior
Closes #34 