### PR TITLE
feat(android): implement ResultScreen with article fetch and WebView …

### DIFF
--- a/android/app/src/androidTest/java/com/wake/dtn/ui/MainViewModelTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/ui/MainViewModelTest.kt
@@ -216,6 +216,126 @@ class MainViewModelTest {
         assertTrue((state as SearchUiState.Results).items.isEmpty())
     }
 
+    // ---- article fetch ----
+
+    @Test
+    fun initialArticleState_isIdle() {
+        assertTrue(viewModel.articleState.value is ArticleUiState.Idle)
+    }
+
+    @Test
+    fun fetchArticle_nullNodeId_staysIdle() = runTest {
+        // nodeId not set — fetchArticle is a no-op
+        viewModel.fetchArticle("/A/Water")
+        advanceUntilIdle()
+        assertTrue(viewModel.articleState.value is ArticleUiState.Idle)
+        assertEquals(WakeScreen.SEARCH, viewModel.currentScreen.value)
+    }
+
+    @Test
+    fun fetchArticle_setsLoadingAndNavigatesToResult() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        // Loading is set synchronously before coroutine dispatches
+        assertTrue(viewModel.articleState.value is ArticleUiState.Loading)
+        assertEquals(WakeScreen.RESULT, viewModel.currentScreen.value)
+    }
+
+    @Test
+    fun fetchArticle_senderThrows_setsArticleError() = runTest {
+        fakeSenderThrows = true
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        advanceUntilIdle()
+        assertTrue(viewModel.articleState.value is ArticleUiState.Error)
+    }
+
+    @Test
+    fun onBundleArrived_articleQuery_setsLoaded() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        advanceUntilIdle()
+
+        val html = "<html><body><h1>Water</h1></body></html>"
+        val bundle = ReassembledBundle(capturedQueryId!!, "text/html", html.toByteArray())
+        viewModel.onBundleArrived(bundle)
+
+        val state = viewModel.articleState.value
+        assertTrue(state is ArticleUiState.Loaded)
+        assertEquals(html, (state as ArticleUiState.Loaded).html)
+    }
+
+    @Test
+    fun onBundleArrived_articleQuery_doesNotUpdateSearchState() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        advanceUntilIdle()
+
+        val html = "<html><body><h1>Water</h1></body></html>"
+        val bundle = ReassembledBundle(capturedQueryId!!, "text/html", html.toByteArray())
+        viewModel.onBundleArrived(bundle)
+
+        // Search state must remain Idle — bundle was for an article, not a search
+        assertTrue(viewModel.searchState.value is SearchUiState.Idle)
+    }
+
+    @Test
+    fun onBundleArrived_searchQuery_doesNotUpdateArticleState() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.onSearchQueryChanged("water")
+        viewModel.submitSearch()
+        advanceUntilIdle()
+
+        val html = """<a href="/A/Water">Water</a>"""
+        val bundle = ReassembledBundle(capturedQueryId!!, "text/html", html.toByteArray())
+        viewModel.onBundleArrived(bundle)
+
+        // Article state must remain Idle — bundle was for a search, not an article
+        assertTrue(viewModel.articleState.value is ArticleUiState.Idle)
+    }
+
+    @Test
+    fun navigateBack_resetsToSearch() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        assertEquals(WakeScreen.RESULT, viewModel.currentScreen.value)
+
+        viewModel.navigateBack()
+
+        assertEquals(WakeScreen.SEARCH, viewModel.currentScreen.value)
+        assertTrue(viewModel.articleState.value is ArticleUiState.Idle)
+    }
+
+    @Test
+    fun navigateBack_thenBundleArrives_isIgnored() = runTest {
+        // Regression: navigateBack() must clear pendingQueryId so a late-arriving
+        // bundle cannot silently flip articleState back to Loaded.
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        advanceUntilIdle()
+
+        val stalePendingId = capturedQueryId!!
+        viewModel.navigateBack()
+
+        val staleBundle = ReassembledBundle(stalePendingId, "text/html", "<h1>Water</h1>".toByteArray())
+        viewModel.onBundleArrived(staleBundle)
+
+        assertTrue(viewModel.articleState.value is ArticleUiState.Idle)
+        assertEquals(WakeScreen.SEARCH, viewModel.currentScreen.value)
+    }
+
+    @Test
+    fun fetchArticle_sendsPathAsQueryString() = runTest {
+        viewModel.setNodeId("node-1")
+        viewModel.fetchArticle("/A/Water")
+        advanceUntilIdle()
+
+        // The capturedQueryId is what was sent to the sender; the path is sent as queryString.
+        // We verify a queryId was indeed captured (sender was invoked) and article state is Loading.
+        assertFalse(capturedQueryId.isNullOrBlank())
+        assertTrue(viewModel.articleState.value is ArticleUiState.Loading)
+    }
+
     // ---- status state ----
 
     @Test

--- a/android/app/src/androidTest/java/com/wake/dtn/ui/ResultScreenTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/ui/ResultScreenTest.kt
@@ -1,0 +1,195 @@
+package com.wake.dtn.ui
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.wake.dtn.data.ReassembledBundle
+import com.wake.dtn.service.RelayController
+import com.wake.dtn.ui.theme.WakeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class ResultScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val fakeRelay = object : RelayController {
+        override fun start(context: Context) = Unit
+        override fun stop(context: Context) = Unit
+    }
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    /** Real WebView created on the main thread; used by WakeWebViewClient tests. */
+    private lateinit var stubView: WebView
+
+    /** Build a ViewModel that captures the queryId sent to the server. */
+    private fun makeViewModelWithCapture(onCapture: (String) -> Unit): MainViewModel {
+        val sender = SearchRequestSender { _, queryId, _ -> onCapture(queryId) }
+        return MainViewModel(fakeRelay, sender, testDispatcher)
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            stubView = WebView(ctx)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun resultScreen_loading_showsProgressIndicator() {
+        // fetchArticle sets Loading synchronously before the coroutine dispatches.
+        val noOpSender = SearchRequestSender { _, _, _ -> }
+        val vm = MainViewModel(fakeRelay, noOpSender, testDispatcher)
+        vm.setNodeId("node-1")
+        vm.fetchArticle("/A/Water")
+
+        composeRule.setContent {
+            WakeTheme { ResultScreen(vm) }
+        }
+
+        composeRule.onNodeWithTag(TAG_RESULT_LOADING).assertIsDisplayed()
+    }
+
+    @Test
+    fun resultScreen_error_showsErrorMessage() {
+        val throwingSender = SearchRequestSender { _, _, _ ->
+            throw java.io.IOException("connection refused")
+        }
+        val vm = MainViewModel(fakeRelay, throwingSender, testDispatcher)
+        vm.setNodeId("node-1")
+        vm.fetchArticle("/A/Water")
+
+        composeRule.setContent {
+            WakeTheme { ResultScreen(vm) }
+        }
+
+        // Advance coroutine scheduler so the error propagates, then pump the compose clock.
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeRule.mainClock.advanceTimeByFrame()
+
+        composeRule.onNodeWithTag(TAG_RESULT_ERROR).assertIsDisplayed()
+        composeRule.onNodeWithText("Error: connection refused", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun resultScreen_loaded_showsWebView() {
+        var capturedId: String? = null
+        val vm = makeViewModelWithCapture { capturedId = it }
+        vm.setNodeId("node-1")
+        vm.fetchArticle("/A/Water")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val html = "<html><body><h1>Water</h1></body></html>"
+        vm.onBundleArrived(ReassembledBundle(capturedId!!, "text/html", html.toByteArray()))
+
+        composeRule.setContent {
+            WakeTheme { ResultScreen(vm) }
+        }
+
+        composeRule.onNodeWithTag(TAG_RESULT_WEBVIEW).assertIsDisplayed()
+    }
+
+    @Test
+    fun resultScreen_navigateBack_returnsToSearch() {
+        val noOpSender = SearchRequestSender { _, _, _ -> }
+        val vm = MainViewModel(fakeRelay, noOpSender, testDispatcher)
+        vm.setNodeId("node-1")
+        vm.fetchArticle("/A/Water")
+
+        composeRule.setContent {
+            WakeTheme { ResultScreen(vm) }
+        }
+
+        vm.navigateBack()
+        composeRule.mainClock.advanceTimeByFrame()
+
+        assert(vm.currentScreen.value == WakeScreen.SEARCH)
+        assert(vm.articleState.value is ArticleUiState.Idle)
+    }
+
+    // ---- WakeWebViewClient path filtering ----
+    //
+    // shouldOverrideUrlLoading never accesses `view`, so a real WebView created
+    // in setUp suffices; it is only present to satisfy the non-null parameter type.
+
+    private fun fakeRequest(url: String): WebResourceRequest {
+        val uri = Uri.parse(url)
+        return object : WebResourceRequest {
+            override fun getUrl() = uri
+            override fun isForMainFrame() = true
+            override fun isRedirect() = false
+            override fun hasGesture() = false
+            override fun getMethod() = "GET"
+            override fun getRequestHeaders() = emptyMap<String, String>()
+        }
+    }
+
+    @Test
+    fun webViewClient_articlePath_firesCallback() {
+        var received: String? = null
+        val client = WakeWebViewClient { received = it }
+        client.shouldOverrideUrlLoading(stubView, fakeRequest("http://localhost/A/Water"))
+        assertEquals("/A/Water", received)
+    }
+
+    @Test
+    fun webViewClient_contentPath_firesCallback() {
+        var received: String? = null
+        val client = WakeWebViewClient { received = it }
+        client.shouldOverrideUrlLoading(stubView, fakeRequest("http://localhost/content/images/logo.png"))
+        assertEquals("/content/images/logo.png", received)
+    }
+
+    @Test
+    fun webViewClient_midPathArticleSegment_doesNotFireCallback() {
+        // Regression for Bug 2: "/wikipedia_en/A/Water" contains "/A/" but does NOT start with it.
+        var received: String? = null
+        val client = WakeWebViewClient { received = it }
+        client.shouldOverrideUrlLoading(stubView, fakeRequest("http://localhost/wikipedia_en/A/Water"))
+        assertNull(received)
+    }
+
+    @Test
+    fun webViewClient_staticResource_doesNotFireCallback() {
+        var received: String? = null
+        val client = WakeWebViewClient { received = it }
+        client.shouldOverrideUrlLoading(stubView, fakeRequest("http://localhost/static/style.css"))
+        assertNull(received)
+    }
+
+    @Test
+    fun webViewClient_alwaysBlocksNavigation() {
+        val client = WakeWebViewClient { }
+        // Returns true (override) for all URLs — WebView must never make direct requests.
+        val blocked = client.shouldOverrideUrlLoading(stubView, fakeRequest("https://en.wikipedia.org/wiki/Water"))
+        assert(blocked)
+    }
+}

--- a/android/app/src/main/java/com/wake/dtn/MainActivity.kt
+++ b/android/app/src/main/java/com/wake/dtn/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import com.wake.dtn.service.WakeService
 import com.wake.dtn.ui.MainViewModel
+import com.wake.dtn.ui.ResultScreen
 import com.wake.dtn.ui.SearchScreen
 import com.wake.dtn.ui.StatusScreen
 import com.wake.dtn.ui.WakeScreen
@@ -63,25 +64,28 @@ class MainActivity : ComponentActivity() {
                 val currentScreen by viewModel.currentScreen.collectAsState()
                 Scaffold(
                     bottomBar = {
-                        NavigationBar {
-                            NavigationBarItem(
-                                selected = currentScreen == WakeScreen.SEARCH,
-                                onClick = { viewModel.navigateTo(WakeScreen.SEARCH) },
-                                icon = { Icon(Icons.Default.Search, contentDescription = "Search") },
-                                label = { Text("Search") },
-                            )
-                            NavigationBarItem(
-                                selected = currentScreen == WakeScreen.STATUS,
-                                onClick = { viewModel.navigateTo(WakeScreen.STATUS) },
-                                icon = { Icon(Icons.Default.Info, contentDescription = "Status") },
-                                label = { Text("Status") },
-                            )
+                        if (currentScreen != WakeScreen.RESULT) {
+                            NavigationBar {
+                                NavigationBarItem(
+                                    selected = currentScreen == WakeScreen.SEARCH,
+                                    onClick = { viewModel.navigateTo(WakeScreen.SEARCH) },
+                                    icon = { Icon(Icons.Default.Search, contentDescription = "Search") },
+                                    label = { Text("Search") },
+                                )
+                                NavigationBarItem(
+                                    selected = currentScreen == WakeScreen.STATUS,
+                                    onClick = { viewModel.navigateTo(WakeScreen.STATUS) },
+                                    icon = { Icon(Icons.Default.Info, contentDescription = "Status") },
+                                    label = { Text("Status") },
+                                )
+                            }
                         }
                     },
                 ) { innerPadding ->
                     when (currentScreen) {
                         WakeScreen.SEARCH -> SearchScreen(viewModel, Modifier.padding(innerPadding))
                         WakeScreen.STATUS -> StatusScreen(viewModel, Modifier.padding(innerPadding))
+                        WakeScreen.RESULT -> ResultScreen(viewModel, Modifier.padding(innerPadding))
                     }
                 }
             }

--- a/android/app/src/main/java/com/wake/dtn/ui/MainViewModel.kt
+++ b/android/app/src/main/java/com/wake/dtn/ui/MainViewModel.kt
@@ -20,7 +20,16 @@ import java.util.UUID
 
 // ---- Screen navigation ----
 
-enum class WakeScreen { SEARCH, STATUS }
+enum class WakeScreen { SEARCH, STATUS, RESULT }
+
+// ---- Article UI state ----
+
+sealed class ArticleUiState {
+    object Idle : ArticleUiState()
+    object Loading : ArticleUiState()
+    data class Loaded(val html: String) : ArticleUiState()
+    data class Error(val message: String) : ArticleUiState()
+}
 
 // ---- Search UI state ----
 
@@ -65,11 +74,17 @@ class MainViewModel(
     private val _lastSyncTimeMs = MutableStateFlow<Long?>(null)
     val lastSyncTimeMs: StateFlow<Long?> = _lastSyncTimeMs.asStateFlow()
 
+    private val _articleState = MutableStateFlow<ArticleUiState>(ArticleUiState.Idle)
+    val articleState: StateFlow<ArticleUiState> = _articleState.asStateFlow()
+
     /** The node ID provided by the bound WakeService. Null when service is not connected. */
     private var nodeId: String? = null
 
-    /** The query ID of the most recently submitted search, awaiting a response bundle. */
+    /** The query ID of the most recently submitted search or article fetch, awaiting a response bundle. */
     private var pendingQueryId: String? = null
+
+    private enum class PendingQueryType { SEARCH, ARTICLE }
+    private var pendingQueryType: PendingQueryType = PendingQueryType.SEARCH
 
     fun startRelay(context: Context) {
         relay.start(context)
@@ -105,6 +120,7 @@ class MainViewModel(
 
         val queryId = UUID.randomUUID().toString()
         pendingQueryId = queryId
+        pendingQueryType = PendingQueryType.SEARCH
         _searchState.value = SearchUiState.Loading
 
         viewModelScope.launch(ioDispatcher) {
@@ -115,6 +131,37 @@ class MainViewModel(
                 pendingQueryId = null
             }
         }
+    }
+
+    /**
+     * Fetch an article from the WAKE server by its kiwix path (e.g. "/A/Water").
+     * Navigates to [WakeScreen.RESULT] immediately and shows a loading indicator until
+     * the reassembled bundle arrives.
+     * No-op if the service is not yet connected (nodeId == null).
+     */
+    fun fetchArticle(path: String) {
+        val id = nodeId ?: return
+        val queryId = UUID.randomUUID().toString()
+        pendingQueryId = queryId
+        pendingQueryType = PendingQueryType.ARTICLE
+        _articleState.value = ArticleUiState.Loading
+        _currentScreen.value = WakeScreen.RESULT
+
+        viewModelScope.launch(ioDispatcher) {
+            try {
+                searchSender.send(id, queryId, path)
+            } catch (e: Exception) {
+                _articleState.value = ArticleUiState.Error(e.message ?: "Network error")
+                pendingQueryId = null
+            }
+        }
+    }
+
+    /** Navigate back to the Search screen and reset article state. */
+    fun navigateBack() {
+        _currentScreen.value = WakeScreen.SEARCH
+        _articleState.value = ArticleUiState.Idle
+        pendingQueryId = null
     }
 
     /**
@@ -131,20 +178,24 @@ class MainViewModel(
         }
 
         val html = bundle.bytes.decodeToString()
-        val results = parseSearchResults(html)
         Log.i(
             TAG,
-            "Search bundle received queryId=${bundle.queryId} contentType=${bundle.contentType} bytes=${bundle.bytes.size} parsedResults=${results.size}",
+            "Bundle received queryId=${bundle.queryId} type=$pendingQueryType contentType=${bundle.contentType} bytes=${bundle.bytes.size}",
         )
-        if (results.isEmpty()) {
-            val preview = html.replace("\n", " ").replace("\r", " ").take(180)
-            Log.w(
-                TAG,
-                "Parsed zero results for queryId=${bundle.queryId}. HTML preview=$preview",
-            )
-        }
 
-        _searchState.value = SearchUiState.Results(results)
+        when (pendingQueryType) {
+            PendingQueryType.SEARCH -> {
+                val results = parseSearchResults(html)
+                if (results.isEmpty()) {
+                    val preview = html.replace("\n", " ").replace("\r", " ").take(180)
+                    Log.w(TAG, "Parsed zero results for queryId=${bundle.queryId}. HTML preview=$preview")
+                }
+                _searchState.value = SearchUiState.Results(results)
+            }
+            PendingQueryType.ARTICLE -> {
+                _articleState.value = ArticleUiState.Loaded(html)
+            }
+        }
         pendingQueryId = null
     }
 

--- a/android/app/src/main/java/com/wake/dtn/ui/ResultScreen.kt
+++ b/android/app/src/main/java/com/wake/dtn/ui/ResultScreen.kt
@@ -1,0 +1,93 @@
+package com.wake.dtn.ui
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+
+const val TAG_RESULT_WEBVIEW = "result_webview"
+const val TAG_RESULT_LOADING = "result_loading"
+const val TAG_RESULT_ERROR = "result_error"
+
+@Composable
+fun ResultScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+    val articleState by viewModel.articleState.collectAsState()
+
+    BackHandler { viewModel.navigateBack() }
+
+    when (val state = articleState) {
+        is ArticleUiState.Idle -> Unit
+        is ArticleUiState.Loading -> {
+            Box(
+                modifier = modifier.fillMaxSize().testTag(TAG_RESULT_LOADING),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        is ArticleUiState.Loaded -> {
+            val html = state.html
+            AndroidView(
+                factory = { ctx ->
+                    WebView(ctx).apply {
+                        webViewClient = WakeWebViewClient { path -> viewModel.fetchArticle(path) }
+                        settings.javaScriptEnabled = false
+                    }
+                },
+                update = { webView ->
+                    webView.loadDataWithBaseURL(
+                        "http://localhost/",
+                        html,
+                        "text/html",
+                        "UTF-8",
+                        null,
+                    )
+                },
+                modifier = modifier.fillMaxSize().testTag(TAG_RESULT_WEBVIEW),
+            )
+        }
+        is ArticleUiState.Error -> {
+            Box(
+                modifier = modifier.fillMaxSize().padding(16.dp).testTag(TAG_RESULT_ERROR),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Error: ${state.message}",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Intercepts navigation events inside the article WebView.
+ * Article links (/A/... or /content/...) are routed back through WAKE.
+ * All other navigations are blocked — the WebView never makes direct internet requests.
+ */
+internal class WakeWebViewClient(
+    private val onArticleLinkClicked: (String) -> Unit,
+) : WebViewClient() {
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        val path = request.url.path ?: return true
+        if (path.startsWith("/A/") || path.startsWith("/content/")) {
+            onArticleLinkClicked(path)
+        }
+        return true
+    }
+}

--- a/android/app/src/main/java/com/wake/dtn/ui/SearchScreen.kt
+++ b/android/app/src/main/java/com/wake/dtn/ui/SearchScreen.kt
@@ -1,5 +1,6 @@
 package com.wake.dtn.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -83,6 +84,7 @@ fun SearchScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                                 style = MaterialTheme.typography.bodyLarge,
                                 modifier = Modifier
                                     .fillMaxWidth()
+                                    .clickable { viewModel.fetchArticle(result.path) }
                                     .padding(vertical = 12.dp),
                             )
                             HorizontalDivider()


### PR DESCRIPTION
…rendering

Adds end-to-end article navigation for Phase 2 issue #18: tapping a search result fires a WAKE bundle request for the article path, navigates to a new ResultScreen that renders reassembled HTML in a WebView, and intercepts in-article link taps to route them back through WAKE rather than the open web.

- Add ArticleUiState (Idle/Loading/Loaded/Error) and fetchArticle() to MainViewModel
- Add navigateBack() that clears pending article state to prevent stale bundle delivery
- Add WakeWebViewClient intercepting /A/... and /content/... paths
- Hide bottom nav bar on RESULT screen
- Add ResultScreenTest (Compose UI tests) and expand MainViewModelTest with 10 article-fetch cases
Closes #35 