### PR TITLE
feat(security): integrate Google Tink Ed25519 signature verification …

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -73,5 +73,6 @@ dependencies {
     androidTestImplementation(libs.kotlinx.coroutines.test)
     implementation(libs.okhttp)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.tink.android)
     androidTestImplementation(libs.okhttp.mockwebserver)
 }

--- a/android/app/src/androidTest/java/com/wake/dtn/service/BundleVerifierTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/BundleVerifierTest.kt
@@ -1,0 +1,155 @@
+package com.wake.dtn.service
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.crypto.tink.subtle.Ed25519Sign
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BundleVerifierTest {
+
+    companion object {
+        private lateinit var keyPair: Ed25519Sign.KeyPair
+        private lateinit var signer: Ed25519Sign
+        private lateinit var verifier: BundleVerifier
+        private lateinit var wrongKeyVerifier: BundleVerifier
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+            keyPair = Ed25519Sign.KeyPair.newKeyPair()
+            signer = Ed25519Sign(keyPair.privateKey)
+            verifier = BundleVerifier(keyPair.publicKey)
+            val otherPair = Ed25519Sign.KeyPair.newKeyPair()
+            wrongKeyVerifier = BundleVerifier(otherPair.publicKey)
+        }
+
+        private fun makeDto(
+            serverId: String = "wake-server-01",
+            queryId: String = "qid-1",
+            chunkIndex: Int = 0,
+            totalChunks: Int = 1,
+            contentType: String = "text/html",
+            payloadB64: String = "aGVsbG8=",
+            sha256: String = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+            signature: String? = null,
+        ) = ResponseBundleDto(
+            serverId = serverId,
+            queryId = queryId,
+            chunkIndex = chunkIndex,
+            totalChunks = totalChunks,
+            contentType = contentType,
+            payloadB64 = payloadB64,
+            sha256 = sha256,
+            signature = signature,
+        )
+
+        private fun sign(dto: ResponseBundleDto): String {
+            val canonical = BundleVerifier.canonicalBytes(dto)
+            return Base64.encodeToString(signer.sign(canonical), Base64.NO_WRAP)
+        }
+    }
+
+    // --- verify() ---
+
+    @Test
+    fun verify_returnsTrue_forValidSignature() {
+        val dto = makeDto()
+        val signed = dto.copy(signature = sign(dto))
+        assertTrue(verifier.verify(signed))
+    }
+
+    @Test
+    fun verify_returnsFalse_forWrongKey() {
+        val dto = makeDto()
+        val signed = dto.copy(signature = sign(dto))
+        assertFalse(wrongKeyVerifier.verify(signed))
+    }
+
+    @Test
+    fun verify_returnsFalse_whenSignatureIsNull() {
+        val dto = makeDto(signature = null)
+        assertFalse(verifier.verify(dto))
+    }
+
+    @Test
+    fun verify_returnsFalse_forTamperedPayloadB64() {
+        val dto = makeDto()
+        val sig = sign(dto)
+        val tampered = dto.copy(payloadB64 = "dGFtcGVyZWQ=", signature = sig)
+        assertFalse(verifier.verify(tampered))
+    }
+
+    @Test
+    fun verify_returnsFalse_forTamperedQueryId() {
+        val dto = makeDto()
+        val sig = sign(dto)
+        val tampered = dto.copy(queryId = "evil-qid", signature = sig)
+        assertFalse(verifier.verify(tampered))
+    }
+
+    @Test
+    fun verify_returnsFalse_forTamperedChunkIndex() {
+        val dto = makeDto(totalChunks = 2)
+        val sig = sign(dto)
+        val tampered = dto.copy(chunkIndex = 1, signature = sig)
+        assertFalse(verifier.verify(tampered))
+    }
+
+    @Test
+    fun verify_returnsFalse_forMalformedBase64Signature() {
+        val dto = makeDto(signature = "not!!valid@@base64")
+        assertFalse(verifier.verify(dto))
+    }
+
+    // --- canonicalBytes() ---
+
+    @Test
+    fun canonicalBytes_producesCorrectJsonShape() {
+        val dto = makeDto(
+            serverId = "wake-server-01",
+            queryId = "qid-1",
+            chunkIndex = 0,
+            totalChunks = 1,
+            contentType = "text/html",
+            payloadB64 = "aGVsbG8=",
+            sha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        )
+        val expected =
+            """{"chunk_index":0,"content_type":"text/html","payload_b64":"aGVsbG8=","query_id":"qid-1","server_id":"wake-server-01","sha256":"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824","total_chunks":1}"""
+        val actual = BundleVerifier.canonicalBytes(dto).toString(Charsets.UTF_8)
+        org.junit.Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun canonicalBytes_excludesSignatureField() {
+        val dto = makeDto(signature = "somesig")
+        val json = BundleVerifier.canonicalBytes(dto).toString(Charsets.UTF_8)
+        assertFalse("canonical bytes must not include signature field", json.contains("\"signature\""))
+    }
+
+    @Test
+    fun canonicalBytes_escapesSpecialCharactersLikeJsonDumps() {
+        // Inject named control chars into a string field to verify Python-compatible escaping.
+        val dto = makeDto(serverId = "id\twith\ttabs\nand\nnewlines\rand\r\ncarriages")
+        val json = BundleVerifier.canonicalBytes(dto).toString(Charsets.UTF_8)
+        assertTrue("tab must be escaped as \\t",      json.contains("\\t"))
+        assertTrue("newline must be escaped as \\n",  json.contains("\\n"))
+        assertTrue("CR must be escaped as \\r",       json.contains("\\r"))
+        assertFalse("raw tab must not appear",        json.contains("\t"))
+        assertFalse("raw newline must not appear",    json.contains("\n"))
+        assertFalse("raw CR must not appear",         json.contains("\r"))
+    }
+
+    @Test
+    fun canonicalBytes_integerFieldsAreNotQuoted() {
+        val dto = makeDto(chunkIndex = 0, totalChunks = 1)
+        val json = BundleVerifier.canonicalBytes(dto).toString(Charsets.UTF_8)
+        assertTrue("chunk_index must be an integer", json.contains("\"chunk_index\":0"))
+        assertTrue("total_chunks must be an integer", json.contains("\"total_chunks\":1"))
+    }
+}

--- a/android/app/src/androidTest/java/com/wake/dtn/service/ServerSyncManagerTest.kt
+++ b/android/app/src/androidTest/java/com/wake/dtn/service/ServerSyncManagerTest.kt
@@ -1,9 +1,11 @@
 package com.wake.dtn.service
 
 import android.content.Context
+import android.util.Base64
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.crypto.tink.subtle.Ed25519Sign
 import com.wake.dtn.data.BundleReassembler
 import com.wake.dtn.data.BundleStoreManager
 import com.wake.dtn.data.BundleType
@@ -35,12 +37,19 @@ class ServerSyncManagerTest {
     private lateinit var syncManager: ServerSyncManager
     private lateinit var testFilesDir: File
 
+    // Ed25519 key pair for signing test chunks.
+    private lateinit var keyPair: Ed25519Sign.KeyPair
+    private lateinit var signer: Ed25519Sign
+
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     @Before
     fun setUp() {
         server = MockWebServer()
         server.start()
+
+        keyPair = Ed25519Sign.KeyPair.newKeyPair()
+        signer = Ed25519Sign(keyPair.privateKey)
 
         db = Room.inMemoryDatabaseBuilder(context, WakeDatabase::class.java)
             .allowMainThreadQueries()
@@ -55,11 +64,13 @@ class ServerSyncManagerTest {
             dao = db.bundleDao(),
         )
 
+        // Inject the key directly so tests don't need to enqueue a /pubkey mock response.
         syncManager = ServerSyncManager(
             httpClient = WakeHttpClient(baseUrl = server.url("/").toString().trimEnd('/')),
             storeManager = storeManager,
             nodeId = "test-node-id",
             reassembler = BundleReassembler(storeManager, testFilesDir),
+            pubkeyProvider = { keyPair.publicKey },
         )
     }
 
@@ -73,16 +84,38 @@ class ServerSyncManagerTest {
 
     // --- helpers ---
 
+    /** Build an unsigned chunk JSON (used for negative-path tests). */
     private fun chunkJson(
         queryId: String = "qid-1",
         chunkIndex: Int = 0,
         totalChunks: Int = 1,
-        // "aGVsbG8=" is base64("hello"); sha256 must match the decoded bytes.
         payloadB64: String = "aGVsbG8=",
         sha256: String = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        signature: String? = null,
     ) = """{"server_id":"wake-server-01","query_id":"$queryId","chunk_index":$chunkIndex,""" +
         """"total_chunks":$totalChunks,"content_type":"text/html","payload_b64":"$payloadB64",""" +
-        """"sha256":"$sha256","signature":null}"""
+        """"sha256":"$sha256","signature":${if (signature != null) "\"$signature\"" else "null"}}"""
+
+    /** Build a chunk JSON with a valid Ed25519 signature from [signer]. */
+    private fun signedChunkJson(
+        queryId: String = "qid-1",
+        chunkIndex: Int = 0,
+        totalChunks: Int = 1,
+        payloadB64: String = "aGVsbG8=",
+        sha256: String = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    ): String {
+        val dto = ResponseBundleDto(
+            serverId = "wake-server-01",
+            queryId = queryId,
+            chunkIndex = chunkIndex,
+            totalChunks = totalChunks,
+            contentType = "text/html",
+            payloadB64 = payloadB64,
+            sha256 = sha256,
+        )
+        val sig = Base64.encodeToString(signer.sign(BundleVerifier.canonicalBytes(dto)), Base64.NO_WRAP)
+        return chunkJson(queryId, chunkIndex, totalChunks, payloadB64, sha256, signature = sig)
+    }
 
     private fun chunksJson(vararg chunks: String) = "[${chunks.joinToString(",")}]"
 
@@ -124,8 +157,8 @@ class ServerSyncManagerTest {
     @Test
     fun pollAndFetch_storesAllPendingBundles() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-a", "qid-b")))
-        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-a"))))
-        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-b"))))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-a"))))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-b"))))
         syncManager.pollAndFetch()
         val pendingPath = server.takeRequest().path!!
         assertTrue(
@@ -140,7 +173,7 @@ class ServerSyncManagerTest {
     fun pollAndFetch_skipsFailingQueryId_continuesRest() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-fail", "qid-ok")))
         server.enqueue(MockResponse().setResponseCode(404).setBody("Not Found"))
-        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-ok"))))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-ok"))))
         // Must not throw despite the 404 on the first ID
         syncManager.pollAndFetch()
         val pendingPath = server.takeRequest().path!!
@@ -169,7 +202,7 @@ class ServerSyncManagerTest {
     @Test
     fun pollAndFetch_doesNotRefetchAlreadyFetchedQueryId() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-once")))
-        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-once"))))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-once"))))
         syncManager.pollAndFetch()
 
         server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-once")))
@@ -189,7 +222,7 @@ class ServerSyncManagerTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-emit")))
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                chunksJson(chunkJson(queryId = "qid-emit", sha256 = sha256OfHello))
+                chunksJson(signedChunkJson(queryId = "qid-emit", sha256 = sha256OfHello))
             )
         )
 
@@ -205,5 +238,100 @@ class ServerSyncManagerTest {
         assertEquals("qid-emit", bundle.queryId)
         assertEquals("text/html", bundle.contentType)
         assertArrayEquals("hello".toByteArray(), bundle.bytes)
+    }
+
+    // --- signature verification tests ---
+
+    @Test
+    fun pollAndFetch_doesNotStore_whenSignatureIsNull() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-nosig")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-nosig"))))
+        syncManager.pollAndFetch()
+        assertNull(db.bundleDao().getById("qid-nosig:0"))
+    }
+
+    @Test
+    fun pollAndFetch_doesNotStore_whenSignatureIsInvalid() = runTest {
+        // Valid base64 but not a valid signature over this bundle's contents.
+        val badSig = Base64.encodeToString(ByteArray(64) { 0x00 }, Base64.NO_WRAP)
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-badsig")))
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                chunksJson(chunkJson(queryId = "qid-badsig", signature = badSig))
+            )
+        )
+        syncManager.pollAndFetch()
+        assertNull(db.bundleDao().getById("qid-badsig:0"))
+    }
+
+    @Test
+    fun pollAndFetch_doesNotStore_whenSignedWithWrongKey() = runTest {
+        val wrongSigner = Ed25519Sign(Ed25519Sign.KeyPair.newKeyPair().privateKey)
+        val dto = ResponseBundleDto(
+            serverId = "wake-server-01",
+            queryId = "qid-wrongkey",
+            chunkIndex = 0,
+            totalChunks = 1,
+            contentType = "text/html",
+            payloadB64 = "aGVsbG8=",
+            sha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        )
+        val wrongSig = Base64.encodeToString(
+            wrongSigner.sign(BundleVerifier.canonicalBytes(dto)),
+            Base64.NO_WRAP
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-wrongkey")))
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                chunksJson(chunkJson(queryId = "qid-wrongkey", signature = wrongSig))
+            )
+        )
+        syncManager.pollAndFetch()
+        assertNull(db.bundleDao().getById("qid-wrongkey:0"))
+    }
+
+    @Test
+    fun pollAndFetch_retriesQueryId_afterSignatureRejection() = runTest {
+        // First poll: unsigned chunk → verification throws → queryId must NOT enter fetchedQueryIds.
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-retry")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(chunkJson(queryId = "qid-retry"))))
+        syncManager.pollAndFetch()
+        assertNull("bad-sig chunk must not be stored", db.bundleDao().getById("qid-retry:0"))
+
+        // Second poll: same queryId reappears, now with a valid signature → must be accepted.
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-retry")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-retry"))))
+        syncManager.pollAndFetch()
+        assertNotNull("valid-sig chunk must be stored on retry", db.bundleDao().getById("qid-retry:0"))
+    }
+
+    @Test
+    fun pollAndFetch_cachesPubkeyAcrossPolls() = runTest {
+        var providerCallCount = 0
+        val cachingManager = ServerSyncManager(
+            httpClient = WakeHttpClient(baseUrl = server.url("/").toString().trimEnd('/')),
+            storeManager = storeManager,
+            nodeId = "test-node-id",
+            reassembler = BundleReassembler(storeManager, testFilesDir),
+            pubkeyProvider = {
+                providerCallCount++
+                keyPair.publicKey
+            },
+        )
+
+        // First poll: 1 pending query, 1 signed chunk.
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-poll1")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-poll1"))))
+        cachingManager.pollAndFetch()
+
+        // Second poll: different query, same signer.
+        server.enqueue(MockResponse().setResponseCode(200).setBody(pendingJson("qid-poll2")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(chunksJson(signedChunkJson(queryId = "qid-poll2"))))
+        cachingManager.pollAndFetch()
+
+        assertEquals("pubkeyProvider must be called exactly once", 1, providerCallCount)
+        // Both bundles must have been stored (verifier reused correctly).
+        assertNotNull(db.bundleDao().getById("qid-poll1:0"))
+        assertNotNull(db.bundleDao().getById("qid-poll2:0"))
     }
 }

--- a/android/app/src/main/java/com/wake/dtn/service/BundleVerifier.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/BundleVerifier.kt
@@ -1,0 +1,87 @@
+package com.wake.dtn.service
+
+import android.util.Base64
+import android.util.Log
+import com.google.crypto.tink.subtle.Ed25519Verify
+import java.security.GeneralSecurityException
+
+/**
+ * Verifies Ed25519 signatures on incoming [ResponseBundleDto] bundles using Google Tink.
+ *
+ * The server signs a deterministic UTF-8 JSON encoding of all bundle fields except
+ * [ResponseBundleDto.signature], with keys sorted alphabetically (ASCII order) and no
+ * whitespace — mirroring PyNaCl's `json.dumps(sort_keys=True, separators=(",", ":"))`.
+ *
+ * [verifyKeyBytes] is the server's 32-byte raw Ed25519 public key, obtained from GET /pubkey.
+ */
+class BundleVerifier(verifyKeyBytes: ByteArray) {
+
+    private val verifier = Ed25519Verify(verifyKeyBytes)
+
+    /**
+     * Returns true iff [bundle]'s signature is a valid Ed25519 signature over its canonical bytes.
+     * Returns false if the signature is absent, malformed, or invalid.
+     */
+    fun verify(bundle: ResponseBundleDto): Boolean {
+        val sigB64 = bundle.signature ?: return false
+        return try {
+            val sigBytes = Base64.decode(sigB64, Base64.DEFAULT)
+            verifier.verify(sigBytes, canonicalBytes(bundle))
+            true
+        } catch (e: GeneralSecurityException) {
+            Log.w(TAG, "Signature verification failed for queryId=${bundle.queryId} chunk=${bundle.chunkIndex}: ${e.message}")
+            false
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Malformed base64 signature for queryId=${bundle.queryId} chunk=${bundle.chunkIndex}: ${e.message}")
+            false
+        }
+    }
+
+    companion object {
+        private const val TAG = "BundleVerifier"
+
+        /**
+         * Reconstruct the exact bytes the server signed.
+         *
+         * The server calls:
+         *   json.dumps(bundle.model_dump(exclude={"signature"}), sort_keys=True, separators=(",",":"))
+         *
+         * This produces 7 fields in alphabetical key order with no whitespace:
+         *   chunk_index, content_type, payload_b64, query_id, server_id, sha256, total_chunks
+         *
+         * Integer fields (chunk_index, total_chunks) are JSON integers, not strings.
+         */
+        internal fun canonicalBytes(bundle: ResponseBundleDto): ByteArray {
+            val json = buildString {
+                append("{")
+                append("\"chunk_index\":${bundle.chunkIndex},")
+                append("\"content_type\":${jsonString(bundle.contentType)},")
+                append("\"payload_b64\":${jsonString(bundle.payloadB64)},")
+                append("\"query_id\":${jsonString(bundle.queryId)},")
+                append("\"server_id\":${jsonString(bundle.serverId)},")
+                append("\"sha256\":${jsonString(bundle.sha256)},")
+                append("\"total_chunks\":${bundle.totalChunks}")
+                append("}")
+            }
+            return json.toByteArray(Charsets.UTF_8)
+        }
+
+        /**
+         * Emit a JSON string literal matching Python's json.dumps named escape sequences:
+         * \\ \" \b \t \n \f \r. Other control characters (U+0000–U+001F) are absent from
+         * all current bundle field values (UUIDs, base64, hex digests, MIME types), so full
+         * \uXXXX escaping is not needed in practice.
+         */
+        private fun jsonString(value: String): String {
+            val escaped = value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\b", "\\b")
+                .replace("\t", "\\t")
+                .replace("\n", "\\n")
+                .replace("\u000C", "\\f")
+                .replace("\r", "\\r")
+            return "\"$escaped\""
+        }
+    }
+}

--- a/android/app/src/main/java/com/wake/dtn/service/ServerSyncManager.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/ServerSyncManager.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Orchestrates WAKE server sync: submits request bundles, polls for pending results,
@@ -22,8 +24,12 @@ class ServerSyncManager(
     private val storeManager: BundleStoreManager,
     val nodeId: String,
     private val reassembler: BundleReassembler,
+    private val pubkeyProvider: suspend () -> ByteArray = { httpClient.fetchPubkey() },
 ) {
     private val fetchedQueryIds = mutableSetOf<String>()
+
+    private val verifierMutex = Mutex()
+    private var verifier: BundleVerifier? = null
 
     private val _reassembledBundles = MutableSharedFlow<ReassembledBundle>(
         replay = 0,
@@ -53,6 +59,9 @@ class ServerSyncManager(
      * A failure for one query ID is logged and skipped; the rest of the loop continues.
      */
     suspend fun pollAndFetch() {
+        verifierMutex.withLock {
+            if (verifier == null) verifier = BundleVerifier(pubkeyProvider())
+        }
         val pending = httpClient.fetchPending(nodeId)
         if (pending.isEmpty()) return
 
@@ -70,8 +79,12 @@ class ServerSyncManager(
 
     private suspend fun storeChunks(chunks: List<ResponseBundleDto>) {
         if (chunks.isEmpty()) return
+        val v = verifier ?: error("BundleVerifier not initialized")
         val nowMs = System.currentTimeMillis()
         for (chunk in chunks) {
+            if (!v.verify(chunk)) {
+                error("Bundle signature verification failed: queryId=${chunk.queryId} chunk=${chunk.chunkIndex}")
+            }
             val payloadBytes = Base64.decode(chunk.payloadB64, Base64.DEFAULT)
             storeManager.store(chunk.toEntity(nowMs), payloadBytes)
         }

--- a/android/app/src/main/java/com/wake/dtn/service/WakeHttpClient.kt
+++ b/android/app/src/main/java/com/wake/dtn/service/WakeHttpClient.kt
@@ -41,6 +41,11 @@ private data class PendingResponseDto(
     @SerialName("pending_query_ids") val pendingQueryIds: List<String>,
 )
 
+@Serializable
+private data class PubkeyResponseDto(
+    @SerialName("pubkey_b64") val pubkeyB64: String,
+)
+
 /**
  * Thin OkHttp wrapper for the three WAKE server endpoints.
  *
@@ -91,6 +96,19 @@ class WakeHttpClient(
             .get()
             .build()
         return json.decodeFromString<PendingResponseDto>(executeAndGetBody(request)).pendingQueryIds
+    }
+
+    /** GET /pubkey and return the server's 32-byte Ed25519 verify key as raw bytes. */
+    suspend fun fetchPubkey(): ByteArray {
+        val request = Request.Builder()
+            .url(baseHttpUrl.newBuilder().addPathSegment("pubkey").build())
+            .get()
+            .build()
+        val body = executeAndGetBody(request)
+        val dto = json.decodeFromString<PubkeyResponseDto>(body)
+        return android.util.Base64.decode(dto.pubkeyB64, android.util.Base64.DEFAULT).also {
+            require(it.size == 32) { "Unexpected Ed25519 key length: ${it.size}" }
+        }
     }
 
     /** GET /bundle/{queryId} and return all stored response chunks for that query. */

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ksp = "2.3.6"
 coroutinesTest = "1.10.2"
 okhttp = "4.12.0"
 kotlinxSerializationJson = "1.8.1"
+tink = "1.16.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +42,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+tink-android = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
…for bundles

Add BundleVerifier using Tink's Ed25519Verify to authenticate server response bundles before caching. ServerSyncManager lazily fetches and caches the server public key via a new WakeHttpClient.fetchPubkey(), then rejects any chunk whose signature is absent or invalid. Bundles rejected by verification are not added to fetchedQueryIds, so a corrected bundle can be accepted on the next poll.
Closes #36 